### PR TITLE
Use module format for constants instead of JSON

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  errors: {
+    PATTERN_MISSING: 'A valid pattern must be provided',
+    INVALID_ELEMENT: 'A valid HTML input or textarea element must be provided'
+  }
+};

--- a/lib/constants.json
+++ b/lib/constants.json
@@ -1,6 +1,0 @@
-{
-  "errors": {
-    "PATTERN_MISSING": "A valid pattern must be provided",
-    "INVALID_ELEMENT": "A valid HTML input or textarea element must be provided"
-  }
-}


### PR DESCRIPTION
Using the module system will make supporting Webpack easier as it won't require a JSON loader.

This is similar to what we've done in other libraries.