### PR TITLE
Remove deprecated keyIdentifier checks

### DIFF
--- a/lib/key-cannot-mutate-value.js
+++ b/lib/key-cannot-mutate-value.js
@@ -9,25 +9,6 @@ module.exports = function (event) {
   var isAtEnd = selection.start === input.value.length;
   var isShifted = event.shiftKey === true;
 
-  // https://www.w3.org/TR/2009/WD-DOM-Level-3-Events-20090908/#keyset-keyidentifiers
-  switch (event.keyIdentifier) {
-    case undefined: // eslint-disable-line
-    case '': // Selenium
-      break;
-    case 'Tab':
-    case 'U+0009':
-      return true;
-    case 'Backspace':
-    case 'U+0008':
-      return isAtBeginning;
-    case 'Del':
-    case 'Delete':
-    case 'U+007F': // delete at the end
-      return isAtEnd;
-    default:
-      return !/^U\+/.test(event.keyIdentifier);
-  }
-
   // https://www.w3.org/TR/DOM-Level-3-Events/#widl-KeyboardEvent-key
   switch (event.key) {
     case undefined: // eslint-disable-line

--- a/lib/restricted-input.js
+++ b/lib/restricted-input.js
@@ -94,8 +94,8 @@ RestrictedInput.prototype._attachEvents = function () {
 };
 
 RestrictedInput.prototype._isDeletion = function (event) {
-  var isBackspace = event.keyIdentifier === 'U+0008' || event.key === 'Backspace' || event.keyCode === 8;
-  var isDelete = event.keyIdentifier === 'U+007F' || /^(Del|Delete)$/.test(event.key) || event.keyCode === 46;
+  var isBackspace = event.key === 'Backspace' || event.keyCode === 8;
+  var isDelete = /^(Del|Delete)$/.test(event.key) || event.keyCode === 46;
 
   return isDelete || isBackspace;
 };


### PR DESCRIPTION
Closes #6 
Fixes https://github.com/braintree/braintree-web/issues/198
Fixes https://github.com/braintree/braintree-web/issues/195

### Changes

Removes deprecated keyIdentifier logic.

Manually tested in:

- [x] OSX 10.11 Safari (9)
- [x] OSX 10.10 Safari (8)
- [x] iOS 9.3.4 Safari
- [x] OSX 10.11 Chrome
- [x] OSX 10.11 Opera
- [x] Windows 10 Chrome
- [x] Windows 10 Opera
- [x] Android 4.4 Chrome
- [x] Android 4.4 Default Browser

Ran all unit and integration tests.