### PR TITLE
Correct expiration date input

### DIFF
--- a/test/support/index.html
+++ b/test/support/index.html
@@ -78,7 +78,7 @@
     <div class="input-wrapper">
       <label for="expiration">Expiration</label>
       <!-- TODO remove this -->
-      <input id="expiration" type="tel" placeholder="mm/yyyy" data-pattern="{{99}} / {{9999}} / {{99}}" />
+      <input id="expiration" type="tel" placeholder="mm/yyyy" data-pattern="{{99}} / {{9999}}" />
     </div>
 
     <div class="input-wrapper">


### PR DESCRIPTION
Fixes test app to use `MM/YYYY` for pattern instead of `MM/YYYY/XX`