### PR TITLE
Use SC bin for OS

### DIFF
--- a/spec/os.rb
+++ b/spec/os.rb
@@ -1,0 +1,30 @@
+# adapted from http://stackoverflow.com/a/171011/2601552
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.mac?
+   (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.unix?
+    !OS.windows?
+  end
+
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+
+  def OS.get_sauce_bin
+    if OS.linux?
+      type = "linux"
+    elsif OS.mac?
+      type = "osx"
+    else
+      raise "Your OS is not supported for running these tests"
+    end
+
+    "./node_modules/sauce-connect-launcher/sc/sc-4.3.13-#{type}/bin/sc"
+  end
+end

--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -4,6 +4,7 @@
 # For options, check out http://saucelabs.com/docs/platforms
 require "sauce"
 require "sauce/capybara"
+require_relative "./os"
 
 tunnel_id = "restricted-input"
 
@@ -19,7 +20,7 @@ Sauce.config do |c|
     :se_port => 4443
   }
   c["tunnel-identifier"] = tunnel_id
-  c[:sauce_connect_4_executable] = "./node_modules/sauce-connect-launcher/sc/sc-4.3.13-linux/bin/sc"
+  c[:sauce_connect_4_executable] = OS.get_sauce_bin
   c[:browsers] = [
     ["Windows 10", "chrome", nil],
     # Firefox 48 (latest on Sauce) is failing all tests


### PR DESCRIPTION
Uses the correct bin for the OS you're using (osx or linux). Didn't bother testing this on Windows, but I suppose if you had Ruby installed on it, you could run the tests if the correct bin path was supplied.