### PR TITLE
Split out travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   PATH=`echo $PATH | sed "s/\.\/node_modules\/\.bin//g"`;
   export PATH=$PATH:./node_modules/.bin;
   touch .env;
-  rvm install ruby-2.3.0 --binary && rvm use ruby-2.3.0 && bundle install;
-script: npm run test:all
+  if [ $IS_INTEGRATION_TEST ]; then rvm install ruby-2.3.0 --binary && rvm use ruby-2.3.0 && bundle install; else echo "Not an integration test. Skipping Ruby setup"; fi
+script: npm run $TEST
 addons:
   sauce_connect: true
 notifications:
@@ -16,6 +16,11 @@ notifications:
     on_success: change
     on_failure: always
 env:
+  matrix:
+    - TEST="lint"
+    - TEST="test:unit"
+    - TEST="test:integration" PLATFORM="desktop" IS_INTEGRATION_TEST=true
+    - TEST="test:integration" PLATFORM="ios" IS_INTEGRATION_TEST=true
   global:
   - secure: SvjZyrdqFJBWCgduVObookkrTLIer/OF4yILB5uy5DuzDT52vmUGLKWj1Zjevy6PKdoZ3QPdrbrEn8tIRuiiTCbBTi9X3X8cQjVHN1Jxq1w/TIUiCxg1Wt+M+FnS2EamLMo2BFEsCM5qXrLwUd23uLXxMRJKDikBvaq1Lgib+S3CDhROORgEtnZeXXd328NiUNriDadhnC7kTACZ16Urt9ZrTJrXwQLujNJlO/zVxB0dBTV8Hzjp/Qce/D3XFg943xeHj7UuffF9ntcJqGEImY226VVWwk3D78j9zpfOXCIBJD/h/uls77eZzSi/9o2voVqfWHGuuKoRfVC8772kuWoe95Fm8ntFUbEWutDnfhs7aMqSW4rYMbFUSMqf6qBGWse07clk6zx0cZpsC1vscf3QSDQu/joj8ohX6+1Qn4gd+1/Rp3WjLBdWUcTfcODLspahwXZ5xnkzU04m46eO23E++U6WYD22xJnHZVsWHM+aGcDRQYFg07mnzOQwSUs66qXpMLCiL4vFiZ4tTehzTD3iMNF+3cr8WDlgFUH9rNBJjzYJeCOycdxwQg9f7orh/Iwm8TdcWQAxpXaWdfa6KidY/4fDi7gCCoxePjuDHnDXt8e+xlMYIM3fy+xfHb7GWCyGnHdQRxLEPFSTPnTDyWVcg7CSbGl9YmqMRa7SMus=
   - secure: u5obPww8nFh3zcov6B9jBj/7LldTT+jOWOUQv/MxE65G6dFWhyJIiNSG/f7HtYr/ziY77B5a+SIoYd097G5lqrtMj128cCGvamdXye0d3YzrbtVGiN7wS3cXPlRPORcaPhQkRl4tQPsElj742f9FRWXsXLdGDzmpPAJDO0lBk9SZuRfdNvw9nTvoHHZgQxu2/lHaMie6v2B3iXSgmgtTN5r6qXXlDoCxZlCB+4cVY2SVNAwXoNk3DDBYsWdOAzVWaOO28l1NaH5CAoKHpz9x1YjjOdHBER5mG2EogQ5Mo4/CAsO9VuEL5Mp0sfhEG7tPXdM0GktFxiRSGfYGIbaMkRUA2npwhj0cWBPdPGaMTQHZI/anr8VHaxUlEP84gXw8VvavttBpaDS/Wdz5dIy5cbqB2q3xhE0VGaR2fG39O/MA+Oq89ZUhThgS8YqltMOKe5AYM3nIeQje61NUpb7FC5q6VLuIKVfSyak2r+TFSVdI27DwU8/QrTIItl1yYJh9eASMX2VIudUahxz0twK7jXuLc9zYtOHgH4bty997G1Z/sr7vu6upyz6081p2tdPDWXzSVIU0HfLj8wRCFnvI8rkKOWfJUGg8ikKJcWoJON3Q59LiuqnEafDiehUnnuueHw5FRi8gcmw82PvFxtoQLzIxfPPNy8k7P2ghsormLjU=

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "start": "node ./test/support/server.js",
     "development": "npm run build & npm start & chokidar 'lib/**/*.js' -c 'npm run build; echo $(tput setaf 2)rebuilt$(tput sgr0)'",
     "lint": "eslint lib test",
-    "test": "npm run lint && karma start config/karma.js --single-run",
+    "test": "npm run lint && npm run test:unit",
     "test:watch": "karma start config/karma.js",
+    "test:unit": "karma start config/karma.js --single-run",
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
     "test:all": "npm run test && npm run test:integration"
   },

--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -8,6 +8,39 @@ require_relative "./os"
 
 tunnel_id = "restricted-input"
 
+PLATFORM = ENV["PLATFORM"]
+
+def select_browsers
+  browsers = []
+
+  if !PLATFORM || PLATFORM == "desktop"
+    browsers += [
+      ["Windows 10", "chrome", nil],
+      # Firefox 48 (latest on Sauce) is failing all tests
+      ["Windows 10", "firefox", 47],
+      ["OS X 10.11", "safari", nil],
+      ["Windows 7", "internet explorer", "9"],
+      ["Windows 8", "internet explorer", "10"],
+      ["Windows 10", "internet explorer", "11"],
+    ]
+  end
+
+  # if !PLATFORM || PLATFORM == "android"
+  #   browsers += [
+  #     ["Linux", "android", nil],
+  #     ["Linux", "android", "4.4"],
+  #   ]
+  # end
+
+  if !PLATFORM || PLATFORM == "ios"
+    browsers += [
+      ["OS X 10.10", "iphone", "9.2"],
+    ]
+  end
+
+  browsers
+end
+
 Capybara.default_driver = :sauce
 Sauce.config do |c|
   c[:job_name] = tunnel_id
@@ -21,16 +54,5 @@ Sauce.config do |c|
   }
   c["tunnel-identifier"] = tunnel_id
   c[:sauce_connect_4_executable] = OS.get_sauce_bin
-  c[:browsers] = [
-    ["Windows 10", "chrome", nil],
-    # Firefox 48 (latest on Sauce) is failing all tests
-    ["Windows 10", "firefox", 47],
-    ["OS X 10.11", "safari", nil],
-    ["Windows 7", "internet explorer", "9"],
-    ["Windows 8", "internet explorer", "10"],
-    ["Windows 10", "internet explorer", "11"],
-    # ["Linux", "android", nil],
-    # ["Linux", "android", "4.4"],
-    ["OS X 10.10", "iphone", "9.2"],
-  ]
+  c[:browsers] = select_browsers
 end


### PR DESCRIPTION
This splits the travis build into 4 builds

1. lint
2. unit tests
3. integration tests for desktop browsers
4. integration tests for iPhone (the one causing the build timeout)