### PR TITLE
Fix formatting for Safari Autofill

### DIFF
--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -53,6 +53,10 @@ BaseStrategy.prototype._attachListeners = function () {
     self._reformatInput(event);
   });
   self.inputElement.addEventListener('input', function (event) {
+    // Safari AutoFill fires CustomEvents -- mark the input as unformatted without actually unformatting the current value
+    if (!(event instanceof KeyboardEvent)) {
+      self.isFormatted = false;
+    }
     self._reformatInput(event);
   });
   self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));

--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -54,7 +54,7 @@ BaseStrategy.prototype._attachListeners = function () {
   });
   self.inputElement.addEventListener('input', function (event) {
     // Safari AutoFill fires CustomEvents -- mark the input as unformatted without actually unformatting the current value
-    if (!(event instanceof KeyboardEvent)) {
+    if (event instanceof CustomEvent) {
       self.isFormatted = false;
     }
     self._reformatInput(event);


### PR DESCRIPTION
Safari Autofill sends CustomEvents types to the card number input, and
the autofilled values are mangled during `_unformatInput()`. This commit
detects when this occurs and marks the input as unformatted without
actually unformatting the value.