### PR TITLE
Fix ios safari autocomplete bug

### DIFF
--- a/lib/strategies/ios.js
+++ b/lib/strategies/ios.js
@@ -18,7 +18,25 @@ IosStrategy.prototype.getUnformattedValue = function () {
 
 IosStrategy.prototype._attachListeners = function () {
   this.inputElement.addEventListener('keydown', this._keydownListener.bind(this));
-  this.inputElement.addEventListener('input', this._formatListener.bind(this));
+  this.inputElement.addEventListener('input', function (event) {
+    var isCustomEvent = event instanceof CustomEvent;
+    var input = this.inputElement;
+
+    // Safari AutoFill fires CustomEvents
+    // Set state to format before calling format listener
+    if (isCustomEvent) {
+      this._stateToFormat = {
+        selection: {start: 0, end: 0},
+        value: input.value
+      };
+    }
+
+    this._formatListener();
+
+    if (!isCustomEvent) {
+      this._fixLeadingBlankSpaceOnIos();
+    }
+  }.bind(this));
   this.inputElement.addEventListener('focus', this._formatListener.bind(this));
 };
 
@@ -42,8 +60,6 @@ IosStrategy.prototype._formatListener = function () {
 
   input.value = formattedState.value;
   setSelection(input, formattedState.selection.start, formattedState.selection.end);
-
-  this._fixLeadingBlankSpaceOnIos();
 };
 
 IosStrategy.prototype._keydownListener = function (event) {

--- a/lib/strategies/ios.js
+++ b/lib/strategies/ios.js
@@ -20,14 +20,13 @@ IosStrategy.prototype._attachListeners = function () {
   this.inputElement.addEventListener('keydown', this._keydownListener.bind(this));
   this.inputElement.addEventListener('input', function (event) {
     var isCustomEvent = event instanceof CustomEvent;
-    var input = this.inputElement;
 
     // Safari AutoFill fires CustomEvents
     // Set state to format before calling format listener
     if (isCustomEvent) {
       this._stateToFormat = {
         selection: {start: 0, end: 0},
-        value: input.value
+        value: this.inputElement.value
       };
     }
 


### PR DESCRIPTION
The [fix for Safari autocomplete](https://github.com/braintree/restricted-input/pull/19) did not apply to the iOS strategy. 