### PR TITLE
AndroidChromeStrategy: Always unformat input on keydown

### DIFF
--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var keyCannotMutateValue = require('../key-cannot-mutate-value');
 var BaseStrategy = require('./base');
 
 function AndroidChromeStrategy(options) {
@@ -8,6 +9,30 @@ function AndroidChromeStrategy(options) {
 
 AndroidChromeStrategy.prototype = Object.create(BaseStrategy.prototype);
 AndroidChromeStrategy.prototype.constructor = AndroidChromeStrategy;
+
+BaseStrategy.prototype._attachListeners = function () {
+  var self = this;
+
+  self.inputElement.addEventListener('keydown', function (event) {
+    if (keyCannotMutateValue(event)) { return; }
+    self._unformatInput(event);
+  });
+  self.inputElement.addEventListener('keypress', function (event) {
+    if (keyCannotMutateValue(event)) { return; }
+    self._unformatInput(event);
+  });
+  self.inputElement.addEventListener('keyup', function (event) {
+    self._reformatInput(event);
+  });
+  self.inputElement.addEventListener('input', function (event) {
+    // Safari AutoFill fires CustomEvents -- mark the input as unformatted without actually unformatting the current value
+    if (event instanceof CustomEvent) {
+      self.isFormatted = false;
+    }
+    self._reformatInput(event);
+  });
+  self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));
+};
 
 AndroidChromeStrategy.prototype._prePasteEventHandler = function () {
   // the default strategy calls preventDefault here

--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -17,16 +17,21 @@ AndroidChromeStrategy.prototype._attachListeners = function () {
     if (keyCannotMutateValue(event)) { return; }
     self._unformatInput(event);
   });
+
+  // 'keypress' is not fired with some Android keyboards (see #23)
   self.inputElement.addEventListener('keypress', function (event) {
     if (keyCannotMutateValue(event)) { return; }
     self._unformatInput(event);
   });
+
   self.inputElement.addEventListener('keyup', function (event) {
     self._reformatInput(event);
   });
+
   self.inputElement.addEventListener('input', function (event) {
     self._reformatInput(event);
   });
+
   self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));
 };
 

--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -10,7 +10,7 @@ function AndroidChromeStrategy(options) {
 AndroidChromeStrategy.prototype = Object.create(BaseStrategy.prototype);
 AndroidChromeStrategy.prototype.constructor = AndroidChromeStrategy;
 
-BaseStrategy.prototype._attachListeners = function () {
+AndroidChromeStrategy.prototype._attachListeners = function () {
   var self = this;
 
   self.inputElement.addEventListener('keydown', function (event) {

--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -25,10 +25,6 @@ BaseStrategy.prototype._attachListeners = function () {
     self._reformatInput(event);
   });
   self.inputElement.addEventListener('input', function (event) {
-    // Safari AutoFill fires CustomEvents -- mark the input as unformatted without actually unformatting the current value
-    if (event instanceof CustomEvent) {
-      self.isFormatted = false;
-    }
     self._reformatInput(event);
   });
   self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));


### PR DESCRIPTION
With third party keyboards on Android, the `keypress` event never occurs. We still get the `keydown` event, but currently, we only unformat if the event `_isDeletion`.

This removes the `_isDeletion` check and always unformats on `keydown`.

Keyboards:
- [x] Google keyboard
- [x] Samsung keyboard
- [x] TouchPal
- [ ] ~Sony Xperia (pressing delete does not activate auto formatting)~ Wasn't able to find on Google Play store
- [x] Swype
- [x] SwiftKey Keyboard

Other actions:
- [x] Autofill
- [x] Pastes - they don't work with the Samsung `Clipboard` feature, but normal pastes appear to be fine