### PR TITLE
Improve Android Formatting with Samsung Keyboard

### DIFF
--- a/lib/input-selection.js
+++ b/lib/input-selection.js
@@ -17,7 +17,13 @@ function set(element, start, end) {
   // Some browsers explode if you use setSelectionRange
   // on a non-focused element
   if (document.activeElement === element && element.setSelectionRange) {
-    element.setSelectionRange(start, end);
+    // Some Android Chrome keyboards need to
+    // be in a setTimeout before setting selection
+    // or the selection will be off when accounting
+    // for permacharacters
+    setTimeout(function () {
+      element.setSelectionRange(start, end);
+    }, 0);
   }
 }
 

--- a/lib/input-selection.js
+++ b/lib/input-selection.js
@@ -17,13 +17,7 @@ function set(element, start, end) {
   // Some browsers explode if you use setSelectionRange
   // on a non-focused element
   if (document.activeElement === element && element.setSelectionRange) {
-    // Some Android Chrome keyboards need to
-    // be in a setTimeout before setting selection
-    // or the selection will be off when accounting
-    // for permacharacters
-    setTimeout(function () {
-      element.setSelectionRange(start, end);
-    }, 0);
+    element.setSelectionRange(start, end);
   }
 }
 

--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -2,6 +2,8 @@
 
 var keyCannotMutateValue = require('../key-cannot-mutate-value');
 var BaseStrategy = require('./base');
+var getSelection = require('../input-selection').get;
+var setSelection = require('../input-selection').set;
 
 function AndroidChromeStrategy(options) {
   BaseStrategy.call(this, options);
@@ -44,6 +46,27 @@ AndroidChromeStrategy.prototype._prePasteEventHandler = function () {
 AndroidChromeStrategy.prototype._postPasteEventHandler = function () {
   // the default strategy calls this without a timeout
   setTimeout(this._reformatAfterPaste.bind(this), 0);
+};
+
+AndroidChromeStrategy.prototype._afterReformatInput = function (formattedState) {
+  var input = this.inputElement;
+
+  // Some Android Chrome keyboards (notably Samsung)
+  // cause the browser to not know that the value
+  // of the input has changed when adding
+  // permacharacters. This results in the selection
+  // putting the cursor before the permacharacter,
+  // instead of after. So we setTimeout and check
+  // the position of the cursor. If it does not match
+  // the formatted input, we set it again
+  setTimeout(function () {
+    var formattedSelection = formattedState.selection;
+    var selection = getSelection(input);
+
+    if (selection.start !== formattedSelection.start) {
+      setSelection(input, formattedSelection.start, formattedSelection.end);
+    }
+  }, 0);
 };
 
 module.exports = AndroidChromeStrategy;

--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -81,10 +81,13 @@ BaseStrategy.prototype._reformatInput = function () {
   input.value = formattedState.value;
   setSelection(input, formattedState.selection.start, formattedState.selection.end);
 
-  if (this._afterReformatInput) {
-    this._afterReformatInput(formattedState);
-  }
+  this._afterReformatInput(formattedState);
 };
+
+// If a strategy needs to impliment specific behavior
+// after reformatting has happend, the strategy just
+// overwrites this method on their own prototype
+BaseStrategy.prototype._afterReformatInput = function () { };
 
 BaseStrategy.prototype._unformatInput = function () {
   var input, unformattedState, selection;

--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -80,6 +80,10 @@ BaseStrategy.prototype._reformatInput = function () {
 
   input.value = formattedState.value;
   setSelection(input, formattedState.selection.start, formattedState.selection.end);
+
+  if (this._afterReformatInput) {
+    this._afterReformatInput(formattedState);
+  }
 };
 
 BaseStrategy.prototype._unformatInput = function () {


### PR DESCRIPTION
Here's what was happening. 

**Pattern:** `{{9999}} {{9999}} {{9999}} {{9999}}`

In a desktop chrome, typing `1234` will automatically add a space, so the value of the input is `1234 ` and set the selection to be after the space.

In Android Chrome, on some keyboards, typing `1234` also automatically added the space, so you could inspect the value of the input and it would be `1234 `, but setting the selection it was as if the input was still `1234`, so the selection would happen after the 4 and *before* the space. This would repeat when continuing to type, giving us this effect:

![ezgif com-optimize](https://cloud.githubusercontent.com/assets/466760/21166758/60143c6c-c15c-11e6-8979-2a3db0f5b668.gif)

So, for some reason, the input's value in the DOM was not being updated until after the selection was done. By setting the setSelection code in a timeout, it works.