### PR TITLE
Disable restricted input in SamsungBrowser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Release Notes
 
+## UNRELEASED
+
+* Disable restricted input in the Samsung Browser
+
 ## 1.0.8 (2017-01-18)
 
 * Fix for Samsung keyboards reporting a ranged selection on first character input

--- a/lib/device.js
+++ b/lib/device.js
@@ -31,8 +31,14 @@ function isIos(ua) {
   return /iPhone|iPod|iPad/.test(ua);
 }
 
+function isSamsungBrowser(ua) {
+  ua = ua || UA;
+  return /SamsungBrowser/.test(ua);
+}
+
 module.exports = {
   isIE9: isIE9,
   isAndroidChrome: isAndroidChrome,
-  isIos: isIos
+  isIos: isIos,
+  isSamsungBrowser: isSamsungBrowser
 };

--- a/lib/restricted-input.js
+++ b/lib/restricted-input.js
@@ -26,7 +26,16 @@ function RestrictedInput(options) {
     throw new Error(constants.errors.PATTERN_MISSING);
   }
 
-  if (device.isIos()) {
+  // SamsungBrowser contains 'Chrome' in userAgent, so check it first
+  if (device.isSamsungBrowser()) {
+    // Disable formatting due to various digits being dropped
+    this.strategy = {
+      getUnformattedValue: function () {
+        return options.element.value;
+      },
+      setPattern: function () {}
+    };
+  } else if (device.isIos()) {
     this.strategy = new IosStrategy(options);
   } else if (device.isAndroidChrome()) {
     this.strategy = new AndroidChromeStrategy(options);

--- a/lib/restricted-input.js
+++ b/lib/restricted-input.js
@@ -7,6 +7,7 @@ var IosStrategy = require('./strategies/ios');
 var AndroidChromeStrategy = require('./strategies/android-chrome');
 var IE9Strategy = require('./strategies/ie9');
 var BaseStrategy = require('./strategies/base');
+var NoopStrategy = require('./strategies/noop');
 
 /**
  * Instances of this class can be used to modify the formatter for an input
@@ -29,12 +30,7 @@ function RestrictedInput(options) {
   // SamsungBrowser contains 'Chrome' in userAgent, so check it first
   if (device.isSamsungBrowser()) {
     // Disable formatting due to various digits being dropped
-    this.strategy = {
-      getUnformattedValue: function () {
-        return options.element.value;
-      },
-      setPattern: function () {}
-    };
+    this.strategy = new NoopStrategy(options);
   } else if (device.isIos()) {
     this.strategy = new IosStrategy(options);
   } else if (device.isAndroidChrome()) {

--- a/lib/strategies/android-chrome.js
+++ b/lib/strategies/android-chrome.js
@@ -33,7 +33,7 @@ AndroidChromeStrategy.prototype._attachListeners = function () {
     self._reformatInput(event);
   });
 
-  self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));
+  self.inputElement.addEventListener('paste', this._pasteEventHandler.bind(this));
 };
 
 AndroidChromeStrategy.prototype._prePasteEventHandler = function () {

--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -59,7 +59,7 @@ BaseStrategy.prototype._attachListeners = function () {
     }
     self._reformatInput(event);
   });
-  self.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));
+  self.inputElement.addEventListener('paste', this._pasteEventHandler.bind(this));
 };
 
 BaseStrategy.prototype._isDeletion = function (event) {
@@ -118,7 +118,7 @@ BaseStrategy.prototype._postPasteEventHandler = function () {
   this._reformatAfterPaste();
 };
 
-BaseStrategy.prototype.pasteEventHandler = function (event) {
+BaseStrategy.prototype._pasteEventHandler = function (event) {
   var selection, splicedEntry;
   var entryValue = '';
 

--- a/lib/strategies/ie9.js
+++ b/lib/strategies/ie9.js
@@ -19,7 +19,7 @@ IE9Strategy.prototype.getUnformattedValue = function () {
 IE9Strategy.prototype._attachListeners = function () {
   this.inputElement.addEventListener('keydown', this._keydownListener.bind(this));
   this.inputElement.addEventListener('focus', this._format.bind(this));
-  this.inputElement.addEventListener('paste', this.pasteEventHandler.bind(this));
+  this.inputElement.addEventListener('paste', this._pasteEventHandler.bind(this));
 };
 
 IE9Strategy.prototype._format = function () {

--- a/lib/strategies/noop.js
+++ b/lib/strategies/noop.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function NoopStrategy(options) {
+  this.inputElement = options.element;
+}
+
+NoopStrategy.prototype.getUnformattedValue = function () {
+  return this.inputElement.value;
+};
+
+NoopStrategy.prototype.setPattern = function () {};
+
+NoopStrategy.prototype.pasteEventHandler = function () {};
+
+module.exports = NoopStrategy;

--- a/lib/strategies/noop.js
+++ b/lib/strategies/noop.js
@@ -10,6 +10,4 @@ NoopStrategy.prototype.getUnformattedValue = function () {
 
 NoopStrategy.prototype.setPattern = function () {};
 
-NoopStrategy.prototype.pasteEventHandler = function () {};
-
 module.exports = NoopStrategy;

--- a/test/unit/lib/device.js
+++ b/test/unit/lib/device.js
@@ -34,7 +34,8 @@ var AGENTS = {
   pcChrome_27: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36',
   pcChrome_41: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
   pcFirefox: 'Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0',
-  pcSafari5_1: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50'
+  pcSafari5_1: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50',
+  samsungBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
 };
 
 describe('device', function () {
@@ -93,6 +94,26 @@ describe('device', function () {
     it('returns false for non-IE9', function () {
       expect(device.isIE9(AGENTS.ie10)).to.equal(false);
       expect(device.isIE9(AGENTS.ie11)).to.equal(false);
+    });
+  });
+
+  describe('isSamsungBrowser', function () {
+    it('returns true for Samsung Browser', function () {
+      expect(device.isSamsungBrowser(AGENTS.samsungBrowser2_1)).to.equal(true);
+    });
+
+    it('returns false when not Samsung Browser', function () {
+      var key, ua;
+
+      for (key in AGENTS) {
+        if (!AGENTS.hasOwnProperty(key)) {
+          continue;
+        }
+        if (!/samsungBrowser/.test(key)) {
+          ua = AGENTS[key];
+          expect(device.isSamsungBrowser(ua)).to.be.false;
+        }
+      }
     });
   });
 });

--- a/test/unit/lib/restricted-input.js
+++ b/test/unit/lib/restricted-input.js
@@ -5,6 +5,7 @@ var BaseStrategy = require('../../../lib/strategies/base');
 var IosStrategy = require('../../../lib/strategies/ios');
 var IE9Strategy = require('../../../lib/strategies/ie9');
 var AndroidChromeStrategy = require('../../../lib/strategies/android-chrome');
+var NoopStrategy = require('../../../lib/strategies/noop');
 var device = require('../../../lib/device');
 
 describe('RestrictedInput', function () {
@@ -77,6 +78,19 @@ describe('RestrictedInput', function () {
       });
 
       expect(ri.strategy).to.be.an.instanceof(IE9Strategy);
+    });
+
+    it('uses NoopStrategy for Samsung browser', function () {
+      var ri;
+
+      global.sandbox.stub(device, 'isSamsungBrowser').returns(true);
+
+      ri = new RestrictedInput({
+        element: document.createElement('input'),
+        pattern: '{{a}}'
+      });
+
+      expect(ri.strategy).to.be.an.instanceof(NoopStrategy);
     });
   });
 

--- a/test/unit/lib/strategies/noop.js
+++ b/test/unit/lib/strategies/noop.js
@@ -12,6 +12,7 @@ describe('Noop Strategy', function () {
       return typeof BaseStrategy.prototype[property] === 'function' && property[0] !== '_';
     });
 
+    expect(noopPublicMethods.length).to.equal(basePublicMethods.length);
     basePublicMethods.forEach(function (method) {
       expect(noopPublicMethods).to.contain(method);
     });

--- a/test/unit/lib/strategies/noop.js
+++ b/test/unit/lib/strategies/noop.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var NoopStrategy = require('../../../../lib/strategies/noop');
+var BaseStrategy = require('../../../../lib/strategies/base');
+
+describe('Noop Strategy', function () {
+  it('has the same public methods as Base Strategy', function () {
+    var noopPublicMethods = Object.getOwnPropertyNames(NoopStrategy.prototype).filter(function (property) {
+      return typeof NoopStrategy.prototype[property] === 'function' && property[0] !== '_';
+    });
+    var basePublicMethods = Object.getOwnPropertyNames(BaseStrategy.prototype).filter(function (property) {
+      return typeof BaseStrategy.prototype[property] === 'function' && property[0] !== '_';
+    });
+
+    basePublicMethods.forEach(function (method) {
+      expect(noopPublicMethods).to.contain(method);
+    });
+  });
+});

--- a/test/unit/lib/strategies/noop.js
+++ b/test/unit/lib/strategies/noop.js
@@ -12,6 +12,7 @@ describe('Noop Strategy', function () {
       return typeof BaseStrategy.prototype[property] === 'function' && property[0] !== '_';
     });
 
+    expect(noopPublicMethods.length > 0).to.equal(true);
     expect(noopPublicMethods.length).to.equal(basePublicMethods.length);
     basePublicMethods.forEach(function (method) {
       expect(noopPublicMethods).to.contain(method);


### PR DESCRIPTION
We observed the following weird behavior with the Samsung Browser:
- Some (random?) numbers would often be dropped from the credit card number field (particularly when entering `4111111111111111`).
- With phone number, if you backspace to the beginning, then the first digit would be dropped.

This PR disables formatting for this browser.