### PR TITLE
Fix formatting for simulated keyboard event

### DIFF
--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -46,6 +46,12 @@ BaseStrategy.prototype._attachListeners = function () {
     }
   });
   self.inputElement.addEventListener('keypress', function (event) {
+    // Simulated event. For example, 1Password sets input.value then fires keyboard events. Dependent on browser
+    // here might be falsy values (key = '', keyCode = 0) or these keys might be omitted
+    if (!event.key && !event.keyCode) {
+      self.isFormatted = false;
+    }
+
     if (keyCannotMutateValue(event)) { return; }
     self._unformatInput(event);
   });


### PR DESCRIPTION
Fix for braintree/braintree-web#262
I've checked this fix with 1Password extension on latest Chrome, Safari and Firefox.