### PR TITLE
Update isSamsung lib to check for old versions of Samsung browser

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -14,6 +14,10 @@ function _isChrome(ua) {
   return CHROME_REGEX.test(ua || UA);
 }
 
+function _isOldSamsungBrowserOrSamsungWebview(ua) {
+  return !_isChrome(ua) && ua.indexOf('Samsung') > -1;
+}
+
 function isIE9(ua) {
   ua = ua || UA;
 
@@ -33,7 +37,7 @@ function isIos(ua) {
 
 function isSamsungBrowser(ua) {
   ua = ua || UA;
-  return /SamsungBrowser/.test(ua);
+  return /SamsungBrowser/.test(ua) || _isOldSamsungBrowserOrSamsungWebview(ua);
 }
 
 module.exports = {

--- a/test/unit/lib/device.js
+++ b/test/unit/lib/device.js
@@ -35,6 +35,8 @@ var AGENTS = {
   pcChrome_41: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
   pcFirefox: 'Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0',
   pcSafari5_1: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50',
+  samsungBrowserWebview: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+  samsungAndroidChrome: 'Mozilla/5.0 (Linux; Android 4.2.2; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36',
   samsungBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
 };
 
@@ -98,8 +100,12 @@ describe('device', function () {
   });
 
   describe('isSamsungBrowser', function () {
-    it('returns true for Samsung Browser', function () {
+    it('returns true for current Samsung Browser', function () {
       expect(device.isSamsungBrowser(AGENTS.samsungBrowser2_1)).to.equal(true);
+    });
+
+    it('returns true for old Samsung Browser and webviews', function () {
+      expect(device.isSamsungBrowser(AGENTS.samsungBrowserWebview)).to.equal(true);
     });
 
     it('returns false when not Samsung Browser', function () {


### PR DESCRIPTION
Originally reported at https://github.com/braintree/braintree-web/issues/265

We recently added a check for native Samsung browsers to disable input formatting entirely. Unfortunately, the user agent we check only applies to newer Samsung devices and we're missing old versions.

The useragent we're currently checking:

```
Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36
```

The useragent for old versions of Samsung

```
Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
```

This check adds some additional logic for the `isSamsungBrowser` check. If the original check returns false, it does a second check to see if the user agent does _not_ contain the word `Chrome` (since newer versions of Samsung browsers using Google Chrome will have Samsung in the user agent) and does contain the word Samsung.