### PR TITLE
Update browser detection to latest major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Release Notes
 
+## Unreleased
+
+* Update browser-detection to latest major version
+
 ## 1.2.4 (2017-06-02)
 
 * Fix LastPass autofill bug

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "publish:demo": "./publish-gh-pages.sh"
   },
   "dependencies": {
-    "@braintree/browser-detection": "1.4.1"
+    "@braintree/browser-detection": "^1.5.0"
   },
   "devDependencies": {
     "browserify": "13.0.1",


### PR DESCRIPTION
Update browser-detection to floating version.

Similar to what we do with [credit-card-type in card-validator](https://github.com/braintree/card-validator/blob/ac06c21e02279df35a22a56ae137641be771e96e/package.json#L26), we pin to a floating major version. Because braintree-web has a pinned version of browser-detection, restricted-input will use whatever version that braintree-web specifies when it is a dependency of braintree-web.

This will eliminate the need to release a new version of restricted input just because an update to browser detection is done.