### PR TITLE
Fix bug where iOS inputs would not paste correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Release Notes
 
+## unreleased
+
+* Fix bug where iOS inputs would not paste correctly
+
 ## 1.2.6 (2017-08-31)
 
 * Add prebublish script to build file before publishing

--- a/lib/strategies/ios.js
+++ b/lib/strategies/ios.js
@@ -37,6 +37,7 @@ IosStrategy.prototype._attachListeners = function () {
     }
   }.bind(this));
   this.inputElement.addEventListener('focus', this._formatListener.bind(this));
+  this.inputElement.addEventListener('paste', this._pasteEventHandler.bind(this));
 };
 
 // When deleting the last character on iOS, the cursor


### PR DESCRIPTION
Turns out we just didn't include the paste handler in the iOS strategey. This PR adds that behavior to the iOS strategy.