### PR TITLE
Fix security vulnerability in dev dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     rspec-retry (0.4.5)
       rspec-core
     rspec-support (3.4.1)
-    rubyzip (1.1.7)
+    rubyzip (1.2.1)
     sauce (3.5.11)
       childprocess (>= 0.1.6)
       cmdparse (>= 2.0.2)
@@ -100,4 +100,4 @@ DEPENDENCIES
   selenium-webdriver
 
 BUNDLED WITH
-   1.11.2
+   1.16.1


### PR DESCRIPTION
Github reported a vulnerability in rubyzip. This is not used in production, so the dev dependency just needs to be updated.