### PR TITLE
Prevent non Chrome Android devices from using input formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Release Notes
 
+## unreleased
+
+* Drop formatting for Android devices not using Google Chrome
+
 ## 1.2.7 (2017-11-01)
 
 * Fix bug where iOS inputs would not paste correctly

--- a/lib/device.js
+++ b/lib/device.js
@@ -11,10 +11,6 @@ var isIE9 = require('@braintree/browser-detection/is-ie9');
 // https://developer.chrome.com/multidevice/user-agent#webview_user_agent
 var KITKAT_WEBVIEW_REGEX = /Version\/\d\.\d* Chrome\/\d*\.0\.0\.0/;
 
-function _isOldSamsungBrowserOrSamsungWebview(ua) {
-  return !isChrome(ua) && ua.indexOf('Samsung') > -1;
-}
-
 function isKitKatWebview(uaArg) {
   var ua = uaArg || UA;
 
@@ -27,15 +23,10 @@ function isAndroidChrome(uaArg) {
   return isAndroid(ua) && isChrome(ua);
 }
 
-function isSamsungBrowser(ua) {
-  ua = ua || UA;
-  return /SamsungBrowser/.test(ua) || _isOldSamsungBrowserOrSamsungWebview(ua);
-}
-
 module.exports = {
   isIE9: isIE9,
+  isAndroid: isAndroid,
   isAndroidChrome: isAndroidChrome,
   isIos: isIos,
-  isKitKatWebview: isKitKatWebview,
-  isSamsungBrowser: isSamsungBrowser
+  isKitKatWebview: isKitKatWebview
 };

--- a/supports-input-formatting.js
+++ b/supports-input-formatting.js
@@ -3,6 +3,8 @@
 var device = require('./lib/device');
 
 module.exports = function () {
-  // Digits get dropped in samsung browser
-  return !device.isSamsungBrowser();
+  // Digits get dropped in non Chrome Android browsers browser
+  // so we only support formatting on non-Android devices
+  // and Android devices using Google Chrome
+  return !device.isAndroid() || device.isAndroidChrome();
 };

--- a/test/unit/lib/device.js
+++ b/test/unit/lib/device.js
@@ -37,19 +37,30 @@ var AGENTS = {
   pcSafari5_1: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50',
   samsungAndroidBrowserWebview: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
   samsungAndroidChrome: 'Mozilla/5.0 (Linux; Android 4.2.2; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36',
-  samsungAndroidBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
+  samsungAndroidBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36',
+  samsungAndroidBrowserSPHL720T: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
 };
 
 describe('device', function () {
   describe('isAndroidChrome()', function () {
     it('returns true if user agent is Chrome for Android', function () {
       expect(device.isAndroidChrome(AGENTS.androidPhoneChrome)).to.equal(true);
+      expect(device.isAndroidChrome(AGENTS.samsungAndroidChrome)).to.equal(true);
     });
 
     it('returns false for Chrome desktop', function () {
       expect(device.isAndroidChrome(AGENTS.pcChrome_27)).to.equal(false);
       expect(device.isAndroidChrome(AGENTS.pcChrome_41)).to.equal(false);
       expect(device.isAndroidChrome(AGENTS.iPhoneChrome)).to.equal(false);
+    });
+
+    it('returns false for Samsung browsers', function () {
+      expect(device.isAndroidChrome(AGENTS.pcChrome_27)).to.equal(false);
+      expect(device.isAndroidChrome(AGENTS.pcChrome_41)).to.equal(false);
+      expect(device.isAndroidChrome(AGENTS.iPhoneChrome)).to.equal(false);
+      expect(device.isAndroidChrome(AGENTS.samsungAndroidBrowserWebview)).to.equal(false);
+      expect(device.isAndroidChrome(AGENTS.samsungAndroidBrowser2_1)).to.equal(false);
+      expect(device.isAndroidChrome(AGENTS.samsungAndroidBrowserSPHL720T)).to.equal(false);
     });
   });
 
@@ -129,6 +140,7 @@ describe('device', function () {
       expect(device.isAndroid(AGENTS.samsungAndroidBrowserWebview)).to.equal(true);
       expect(device.isAndroid(AGENTS.samsungAndroidChrome)).to.equal(true);
       expect(device.isAndroid(AGENTS.samsungAndroidBrowser2_1)).to.equal(true);
+      expect(device.isAndroid(AGENTS.samsungAndroidBrowserSPHL720T)).to.equal(true);
     });
 
     it('returns false when not an Android Device', function () {

--- a/test/unit/lib/device.js
+++ b/test/unit/lib/device.js
@@ -35,9 +35,9 @@ var AGENTS = {
   pcChrome_41: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
   pcFirefox: 'Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0',
   pcSafari5_1: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50',
-  samsungBrowserWebview: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+  samsungAndroidBrowserWebview: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
   samsungAndroidChrome: 'Mozilla/5.0 (Linux; Android 4.2.2; Samsung Galaxy Note 2 - 4.2.2 - API 17 - 720x1280 Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36',
-  samsungBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
+  samsungAndroidBrowser2_1: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG SPH-L720T Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
 };
 
 describe('device', function () {
@@ -117,25 +117,30 @@ describe('device', function () {
     });
   });
 
-  describe('isSamsungBrowser', function () {
-    it('returns true for current Samsung Browser', function () {
-      expect(device.isSamsungBrowser(AGENTS.samsungBrowser2_1)).to.equal(true);
+  describe('isAndroid', function () {
+    it('returns true for Android devices', function () {
+      expect(device.isAndroid(AGENTS.androidOperaMini)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidPhoneChrome)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidPhoneFirefox)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidTabletFirefox)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidWebviewOld)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidWebviewKitKatLollipop)).to.equal(true);
+      expect(device.isAndroid(AGENTS.androidWebviewLollipopAndAbove)).to.equal(true);
+      expect(device.isAndroid(AGENTS.samsungAndroidBrowserWebview)).to.equal(true);
+      expect(device.isAndroid(AGENTS.samsungAndroidChrome)).to.equal(true);
+      expect(device.isAndroid(AGENTS.samsungAndroidBrowser2_1)).to.equal(true);
     });
 
-    it('returns true for old Samsung Browser and webviews', function () {
-      expect(device.isSamsungBrowser(AGENTS.samsungBrowserWebview)).to.equal(true);
-    });
-
-    it('returns false when not Samsung Browser', function () {
+    it('returns false when not an Android Device', function () {
       var key, ua;
 
       for (key in AGENTS) {
         if (!AGENTS.hasOwnProperty(key)) {
           continue;
         }
-        if (!/samsungBrowser/.test(key)) {
+        if (key.toLowerCase().indexOf('android') === -1) {
           ua = AGENTS[key];
-          expect(device.isSamsungBrowser(ua)).to.be.false;
+          expect(device.isAndroid(ua)).to.be.false;
         }
       }
     });

--- a/test/unit/lib/restricted-input.js
+++ b/test/unit/lib/restricted-input.js
@@ -94,10 +94,11 @@ describe('RestrictedInput', function () {
       expect(ri.strategy).to.be.an.instanceof(IE9Strategy);
     });
 
-    it('uses NoopStrategy for Samsung browser', function () {
+    it('uses NoopStrategy for browsers that do not support formatting', function () {
       var ri;
 
-      global.sandbox.stub(device, 'isSamsungBrowser').returns(true);
+      global.sandbox.stub(device, 'isAndroid').returns(true);
+      global.sandbox.stub(device, 'isAndroidChrome').returns(false);
 
       ri = new RestrictedInput({
         element: document.createElement('input'),
@@ -140,14 +141,22 @@ describe('RestrictedInput', function () {
   });
 
   describe('supportsFormatting', function () {
-    it('returns false if device is a samsung browser', function () {
-      global.sandbox.stub(device, 'isSamsungBrowser').returns(true);
+    it('returns false if device is an Android phone not using Google Chrome', function () {
+      global.sandbox.stub(device, 'isAndroid').returns(true);
+      global.sandbox.stub(device, 'isAndroidChrome').returns(false);
 
       expect(RestrictedInput.supportsFormatting()).to.equal(false);
     });
 
-    it('returns true if device is not a Samsung browser', function () {
-      global.sandbox.stub(device, 'isSamsungBrowser').returns(false);
+    it('returns true if device is not a an Android Device', function () {
+      global.sandbox.stub(device, 'isAndroid').returns(false);
+
+      expect(RestrictedInput.supportsFormatting()).to.equal(true);
+    });
+
+    it('returns true if device is an Android Device running Google Chrome', function () {
+      global.sandbox.stub(device, 'isAndroid').returns(true);
+      global.sandbox.stub(device, 'isAndroidChrome').returns(true);
 
       expect(RestrictedInput.supportsFormatting()).to.equal(true);
     });


### PR DESCRIPTION
We got some more reports about Android phones that were not using Google Chrome being unable to enter characters.

This PR turns off input formatting for all Android devices _unless_ they are using Google Chrome.