### PR TITLE
Add hook for paste events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Release Notes
 
+## unreleased
+
+* Add option to include a hook for the unformatted value of the input after pasting
+
 ## 2.0.2
 
 * Update browser-detection dependency to 1.8.0

--- a/README.md
+++ b/README.md
@@ -143,14 +143,35 @@ Some example patterns with behavior are listed:
    - Waits for a single alpha from the user.
    - Inserts `E`.
 
+## Paste Event
+
+If an input is changed via a paste event, you may want to adjust the pattern before input formatting occurs. In this case, pass an `onPasteEvent` callback:
+
+```js
+const formattedCreditCardInput = new RestrictedInput({
+  element: document.querySelector('#credit-card'),
+  pattern: '{{9999}} {{9999}} {{9999}} {{9999}}',
+  onPasteEvent: function (payload) {
+    var value = payload.unformattedInputValue;
+
+    if (requiresAmexPattern(value)) {
+      formattedCreditCardInput.setPattern('{{9999}} {{999999}} {{99999}}')
+    } else {
+      formattedCreditCardInput.setPattern('{{9999}} {{9999}} {{9999}} {{9999}}')
+    }
+  })
+});
+```
+
 ## API
 
 ### options
 
-| Key | Type | Description |
-| --- | ---- | ----------- |
-| element | `HTMLInputElement` or `HTMLTextAreaElement` | A valid reference to an `input` or `textarea` DOM node |
-| pattern | `String` | Pattern describing the allowed character set you wish for entry into corresponding field. See [Patterns](#patterns).|
+| Key          | Type                                        | Description                                                                                                              |
+| ------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| element      | `HTMLInputElement` or `HTMLTextAreaElement` | A valid reference to an `input` or `textarea` DOM node                                                                   |
+| pattern      | `String`                                    | Pattern describing the allowed character set you wish for entry into corresponding field. See [Patterns](#patterns).     |
+| onPasteEvent | `Function` (optional)                       | A callback function to inspect the unformatted value of the input during a paste event. See [Paste Event](#paste-event). |
 
 ## Browser Support
 

--- a/lib/strategies/base.js
+++ b/lib/strategies/base.js
@@ -11,6 +11,7 @@ function BaseStrategy(options) {
   this.isFormatted = false;
   this.inputElement = options.element;
   this.formatter = new Formatter(options.pattern);
+  this._onPasteEvent = options.onPasteEvent;
 
   this._attachListeners();
 
@@ -162,6 +163,12 @@ BaseStrategy.prototype._pasteEventHandler = function (event) {
 
   splicedEntry.splice(selection.start, selection.end - selection.start, entryValue);
   splicedEntry = splicedEntry.join('');
+
+  if (this._onPasteEvent) {
+    this._onPasteEvent({
+      unformattedInputValue: splicedEntry
+    });
+  }
 
   this.inputElement.value = splicedEntry;
   setSelection(this.inputElement, selection.start + entryValue.length, selection.start + entryValue.length);

--- a/test/integration/restricted-input.js
+++ b/test/integration/restricted-input.js
@@ -31,19 +31,9 @@ describe('Restricted Input', function () {
     browser.addCommand('typeKeys', function (keys) {
       this.addValue(keys);
     }, true);
-
-    browser.addCommand('reloadSessionOnRetry', () => {
-      if (this.sessionId === browser.sessionId) {
-        browser.reloadSession();
-      } else {
-        this.sessionId = browser.sessionId;
-      }
-    });
   });
 
   beforeEach(() => {
-    browser.reloadSessionOnRetry();
-
     browser.url('http://bs-local.com:3099');
   });
 

--- a/test/integration/restricted-input.js
+++ b/test/integration/restricted-input.js
@@ -1,8 +1,6 @@
 const expect = require('chai').expect;
 
 describe('Restricted Input', function () {
-  this.retries(3);
-
   before(() => {
     browser.addCommand('name', () => {
       return browser.capabilities.browserName.toUpperCase();
@@ -45,6 +43,7 @@ describe('Restricted Input', function () {
 
   beforeEach(() => {
     browser.reloadSessionOnRetry();
+
     browser.url('http://bs-local.com:3099');
   });
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -109,6 +109,14 @@ if (ONLY_BROWSERS) {
   }
 }
 
+const mochaOpts = {
+  timeout: 90000
+};
+
+if (!process.env.DISABLE_RETRIES) {
+  mochaOpts.retries = 3;
+}
+
 exports.config = {
   runner: 'local',
   user: process.env.BROWSERSTACK_USERNAME,
@@ -129,9 +137,7 @@ exports.config = {
   connectionRetryCount: 1,
   services: ['browserstack'],
   framework: 'mocha',
-  mochaOpts: {
-    timeout: 60000
-  },
+  mochaOpts,
   reporters: ['spec'],
   reportOptions: {
     outputDir: './'

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -71,7 +71,10 @@ let capabilities = [
     browser: 'IE',
     browserName: 'IE 11',
     browser_version: '11.0',
-    'browserstack.selenium_version' : '3.5.2'
+    'browserstack.selenium_version' : '3.141.5',
+    // https://stackoverflow.com/a/42340325/7851516
+    'browserstack.bfcache': '0',
+    'browserstack.ie.arch' : 'x32'
   },
   {
     ...desktopCapabilities,


### PR DESCRIPTION
Turns out, testing the paste behavior was pretty tricky, both at a unit level (since you can't simulate paste events in the browser) and on an integration level (since the drivers give limited access to the keyboard) :(

Since the change was pretty small, and didn't change behavior for other pieces of the lib, we were okay with leaving it untested. (same state the normal paste behavior is)