### PR TITLE
Fix Samsung Internet Browser formatting

### DIFF
--- a/src/lib/restricted-input.ts
+++ b/src/lib/restricted-input.ts
@@ -22,9 +22,7 @@ class RestrictedInput {
   strategy: StrategyInterface;
 
   constructor(options: StrategyOptions) {
-    if (!RestrictedInput.supportsFormatting()) {
-      this.strategy = new NoopStrategy(options);
-    } else if (isIos()) {
+    if (isIos()) {
       this.strategy = new IosStrategy(options);
     } else if (isKitKatWebview()) {
       this.strategy = new KitKatChromiumBasedWebViewStrategy(options);

--- a/src/lib/restricted-input.ts
+++ b/src/lib/restricted-input.ts
@@ -9,7 +9,6 @@ import {
   StrategyOptions,
 } from "./strategies/strategy-interface";
 import { BaseStrategy } from "./strategies/base";
-import { NoopKeyboardStrategy as NoopStrategy } from "./strategies/noop";
 
 /**
  * Instances of this class can be used to modify the formatter for an input

--- a/src/lib/restricted-input.ts
+++ b/src/lib/restricted-input.ts
@@ -1,5 +1,4 @@
 import { isIos, isKitKatWebview, isAndroidChrome, isIE9 } from "./device";
-import supportsInputFormatting = require("../supports-input-formatting");
 import { IosStrategy } from "./strategies/ios";
 import { AndroidChromeStrategy } from "./strategies/android-chrome";
 import { KitKatChromiumBasedWebViewStrategy } from "./strategies/kitkat-chromium-based-webview";
@@ -49,10 +48,6 @@ class RestrictedInput {
    */
   setPattern(pattern: string): void {
     this.strategy.setPattern(pattern);
-  }
-
-  static supportsFormatting(): boolean {
-    return supportsInputFormatting();
   }
 }
 

--- a/src/supports-input-formatting.ts
+++ b/src/supports-input-formatting.ts
@@ -1,6 +1,0 @@
-import { isSamsungBrowser } from "./lib/device";
-
-export = function supportsInputFormatting(): boolean {
-  // Digits get dropped in samsung browser
-  return !isSamsungBrowser();
-};

--- a/test/unit/lib/restricted-input.test.ts
+++ b/test/unit/lib/restricted-input.test.ts
@@ -148,18 +148,4 @@ describe("RestrictedInput", function () {
       expect(ri.strategy.setPattern).toBeCalledWith("{{1}}");
     });
   });
-
-  describe("supportsFormatting", function () {
-    it("returns false if device is a samsung browser", function () {
-      jest.mocked(isSamsungBrowser).mockReturnValue(true);
-
-      expect(RestrictedInput.supportsFormatting()).toBe(false);
-    });
-
-    it("returns true if device is not a Samsung browser", function () {
-      jest.mocked(isSamsungBrowser).mockReturnValue(false);
-
-      expect(RestrictedInput.supportsFormatting()).toBe(true);
-    });
-  });
 });

--- a/test/unit/lib/restricted-input.test.ts
+++ b/test/unit/lib/restricted-input.test.ts
@@ -4,7 +4,6 @@ import { IosStrategy } from "../../../src/lib/strategies/ios";
 import { IE9Strategy } from "../../../src/lib/strategies/ie9";
 import { AndroidChromeStrategy } from "../../../src/lib/strategies/android-chrome";
 import { KitKatChromiumBasedWebViewStrategy } from "../../../src/lib/strategies/kitkat-chromium-based-webview";
-import { NoopKeyboardStrategy as NoopStrategy } from "../../../src/lib/strategies/noop";
 import {
   isIE9,
   isIos,
@@ -107,7 +106,7 @@ describe("RestrictedInput", function () {
       expect(ri.strategy).toBeInstanceOf(IE9Strategy);
     });
 
-    it("uses NoopStrategy for Samsung browser", function () {
+    it("uses BaseStrategy for Samsung browser", function () {
       jest.mocked(isSamsungBrowser).mockReturnValue(true);
 
       const ri = new RestrictedInput({
@@ -115,7 +114,7 @@ describe("RestrictedInput", function () {
         pattern: "{{a}}",
       });
 
-      expect(ri.strategy).toBeInstanceOf(NoopStrategy);
+      expect(ri.strategy).toBeInstanceOf(BaseStrategy);
     });
   });
 


### PR DESCRIPTION
This PR is specifically to fix a bug noted in issue LI-35763 where, in Samsung Internet Browser only, the expiration date was not automatically adding a forward slash and there was no way a user could add it. Because of this, later on in the process (after the submit button was pressed), the date was not validating correctly so the transaction would not go through successfully.

To test: create a sample application with card fields and test locally with BrowserStack (use domain [bs-local.com](http://bs-local.com/)). Choose an Android device with Samsung Internet Browser. Fill in the date using only the phone keypad and ensure the forward slash gets added in automatically.

Integration tests aren’t currently working, but it is recommended to come back and add integration tests for the validation of expiration date in Samsung Internet Browser and several other browsers.

Broken:
<img width="357" alt="Screenshot 2024-03-26 at 9 52 15 AM" src="https://github.com/braintree/restricted-input/assets/13205473/db8b266f-92f6-49d6-8ebe-66a01bdcb51f">
