### PR TITLE
fix: only use main in release processes

### DIFF
--- a/publish-gh-pages.sh
+++ b/publish-gh-pages.sh
@@ -3,7 +3,7 @@ set -e           # aborts if there are errors
 set -u           # errors if you use an undefined variable
 set -o pipefail  # errors if a pipe fails
 
-git checkout master
+git checkout main
 
 npm run build
 


### PR DESCRIPTION
The GH Pages publish step was using `master` as a base branch which is incorrect anymore and very out of date. `main` is the current default branch and should be used for these processes.