### PR TITLE
Fix prettier checks in build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@
 
 ### Reviewers
 
-@braintree/team-sdk-js 
+@braintree/team-sdk-js

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -3,11 +3,11 @@ name: "Integration Tests"
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
   pull_request:
     branches:
-        - '*'
+      - "*"
 
 jobs:
   ubuntu-job:
@@ -30,7 +30,7 @@ jobs:
       - name: "Node Setup"
         uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc 
+          node-version-file: .nvmrc
       - run: npm install
       - run: rm -rf node_modules/@types/mocha
       - run: npm run development & npm run test:integration

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -3,12 +3,12 @@ name: "Unit Tests"
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
   workflow_call:
   pull_request:
     branches:
-        - '*'
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,37 @@
-# This workflow will run tests using node, bump the npm version, deploy to npm, and create a release with notes 
+# This workflow will run tests using node, bump the npm version, deploy to npm, and create a release with notes
 
-name: Publish to npm 
+name: Publish to npm
 run-name: Deploy ${{ github.repository }} to npmjs by @${{ github.actor }}
 on:
-    workflow_dispatch:
-      inputs:
-        version_type:
-          description: "Version bump type (major, minor, patch)"
-          required: true
-          type: choice
-          options:
-            - major
-            - minor
-            - patch
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 env:
-    NPM_REGISTRY: https://registry.npmjs.org/
+  NPM_REGISTRY: https://registry.npmjs.org/
 
 concurrency: # prevent concurrent releases
-  group: npm-publish 
+  group: npm-publish
   cancel-in-progress: true
 
 jobs:
-  ci-unit-tests: 
+  prettier-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: ${{ env.NPM_REGISTRY }}
+      - run: npx prettier -c .
+  ci-unit-tests:
     uses: ./.github/workflows/ci-unit-tests.yml
   bump-version:
     needs: ci-unit-tests
@@ -39,7 +48,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          registry-url: ${{ env.NPM_REGISTRY }} 
+          registry-url: ${{ env.NPM_REGISTRY }}
       - run: git pull # Pull down changes from previous step
       - run: npm ci
       - run: npm publish --provenance
@@ -47,4 +56,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
   publish-release:
     needs: publish-npm
-    uses: ./.github/workflows/release-notes.yml 
+    uses: ./.github/workflows/release-notes.yml

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,7 +1,7 @@
-# This workflow will create a release for the most recent deploy 
+# This workflow will create a release for the most recent deploy
 
-name: Create release 
-run-name: Running github release 
+name: Create release
+run-name: Running github release
 on:
   workflow_dispatch:
   workflow_call:
@@ -36,4 +36,4 @@ jobs:
           release_name: v${{ env.latest_version }}
           body: "${{ env.release_details }}"
           draft: false
-          prerelease: false 
+          prerelease: false

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,9 +16,9 @@ on:
         required: true
         type: choice
         options:
-          - major
-          - minor
           - patch
+          - minor
+          - major
 
 jobs:
   version_bump:
@@ -51,11 +51,11 @@ jobs:
         run: |
           new_version=$(npm version ${{ inputs.version_type }})
           echo "new_version=$(echo $new_version | sed 's/v//')" >> $GITHUB_ENV
-        
+
       - name: Update changelog
         run: |
-           today=$(date +'%Y-%m-%d')
-           sed -i "s/## unreleased/## ${{ env.new_version }} (${today})/i" CHANGELOG.md
+          today=$(date +'%Y-%m-%d')
+          sed -i "s/## unreleased/## ${{ env.new_version }} (${today})/i" CHANGELOG.md
 
       - name: Commit and push changes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Restricted Input - Changelog
 
+## Unreleased
+- Updates workflows and scripts
+  - fix `prettier` issue with deploying GH pages
+
 ## 4.1.0 (2025-02-21)
 
 - Updates dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Restricted Input - Changelog
 
-## Unreleased
+## 4.1.0 (2025-02-21)
 
 - Updates dependencies
   - serialize-javascript to 6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Restricted Input - Changelog
 
 ## Unreleased
+
 - Updates workflows and scripts
   - fix `prettier` issue with deploying GH pages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restricted-input",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "restricted-input",
-      "version": "4.0.3",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@braintree/browser-detection": "^1.17.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restricted-input",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Restrict inputs to certain valid characters (e.g. formatting phone or card numbers)",
   "author": "Braintree <code@getbraintree.com> (https://www.braintreepayments.com/)",
   "license": "MIT",
@@ -24,7 +24,8 @@
     "restrict"
   ],
   "scripts": {
-    "prebuild": "prettier --write .",
+    "prebuild": "prettier --check .",
+    "format": "prettier --write .",
     "build": "tsc --declaration",
     "build:app": "mkdir -p dist-app; browserify ./src/main.ts -p [ tsify --strict ] -o dist-app/restricted-input.js -s RestrictedInput -v",
     "predoc": "npm run build",


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
**package.json**:
- Change `prebuild` from `prettier --write` to `prettier --check`
- Add `format` to run `prettier --write`

**publish.yml**:
- Add a job to check prettier before any other jobs
- Re-order selections for version

**version-bump.yml**:
- Re-order selections for version

❗️ *I re-ordered the version selections to mitigate future human error. It's a lot better for the default option to be patch rather than major in case someone deploys without selecting something.*

### Checklist

- ~Added a changelog entry~ *Changelog unnecessary, no functionality changes*

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @CJGlitter 

### Reviewers

@braintree/team-sdk-js 
