### PR TITLE
Add npm install to prettier job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: ${{ env.NPM_REGISTRY }}
+      - run: npm ci
       - run: npx prettier -c .
   ci-unit-tests:
     needs: prettier-check


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
Prettier check was failing because, without an `npm install`, prettier was [defaulting](https://github.com/braintree/restricted-input/actions/runs/13507279446/job/37739663934#step:4:9) to a later version than we use. Added npm install in.

### Checklist

- [x] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @CJGlitter 

### Reviewers

@braintree/team-sdk-js
