### PR TITLE
Move prettier check from 'prebuild' to ci

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
+      - run: npx prettier --check .
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,7 @@ concurrency: # prevent concurrent releases
   cancel-in-progress: true
 
 jobs:
-  prettier-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          registry-url: ${{ env.NPM_REGISTRY }}
-      - run: npm ci
-      - run: npx prettier -c .
   ci-unit-tests:
-    needs: prettier-check
     uses: ./.github/workflows/ci-unit-tests.yml
   bump-version:
     needs: ci-unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Restricted Input - Changelog
 
+## UNRELEASED
+
+- Updates workflows and scripts
+  - move `prettier` to ci
+
 ## 4.1.0 (2025-02-21)
 
 - Updates workflows and scripts

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "restrict"
   ],
   "scripts": {
-    "prebuild": "prettier --check .",
     "format": "prettier --write .",
     "build": "tsc --declaration",
     "build:app": "mkdir -p dist-app; browserify ./src/main.ts -p [ tsify --strict ] -o dist-app/restricted-input.js -s RestrictedInput -v",


### PR DESCRIPTION
### Summary

<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
Moved prettier check to CI instead of "prebuild" step.

**publish.yml**:
- Remove prettier step

**ci-unit-tests.yml**:
- Add prettier check

**package.json**:
- remove prebuild step

<br>

### Checklist

- [x] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @CJGlitter 

### Reviewers

@braintree/team-sdk-js
