### PR TITLE
Add destroy method

### DIFF
--- a/src/lib/strategies/base.ts
+++ b/src/lib/strategies/base.ts
@@ -71,64 +71,78 @@ export class BaseStrategy extends StrategyInterface {
   }
 
   protected attachListeners(): void {
-    this.inputElement.addEventListener("keydown", (e) => {
-      const event = e as KeyboardEvent;
+    this.inputElement.addEventListener("keydown", this.handleKeyDown);
+    this.inputElement.addEventListener("keypress", this.handleKeyPress);
+    this.inputElement.addEventListener("keyup", this.handleKeyUp);
+    this.inputElement.addEventListener("input", this.handleInput);
+    this.inputElement.addEventListener("paste", this.handlePaste);
+  }
+  
+  destroy(): void {
+	  this.inputElement.removeEventListener("keydown", this.handleKeyDown);
+	  this.inputElement.removeEventListener("keypress", this.handleKeyPress);
+	  this.inputElement.removeEventListener("keyup", this.handleKeyUp);
+	  this.inputElement.removeEventListener("input", this.handleInput);
+	  this.inputElement.removeEventListener("paste", this.handlePaste);
+  }
 
-      if (isSimulatedEvent(event)) {
-        this.isFormatted = false;
-      }
+  private handleKeyDown(e: Event): void {
+	  const event = e as KeyboardEvent;
+	
+	  if (isSimulatedEvent(event)) {
+	    this.isFormatted = false;
+	  }
+	
+	  if (keyCannotMutateValue(event)) {
+	    return;
+	  }
+	
+	  if (this.isDeletion(event)) {
+	    this.unformatInput();
+	  }
+  }
 
-      if (keyCannotMutateValue(event)) {
-        return;
-      }
-
-      if (this.isDeletion(event)) {
-        this.unformatInput();
-      }
-    });
-
-    this.inputElement.addEventListener("keypress", (e) => {
-      this.hasKeypressEvent = true;
-      this.onKeypress(e as KeyboardEvent);
-    });
-
-    this.inputElement.addEventListener("keyup", () => {
-      this.reformatInput();
-      // if the user changes their keyboard and
-      // the browser doesn't support the keypress event listener,
-      // we need to reset the keypress flag to be able to enable the
-      // fallback for the custom input event listener
-      // to be able to format the field
-      this.hasKeypressEvent = false;
-    });
-
-    this.inputElement.addEventListener("input", (e) => {
-      const event = e as KeyboardEvent;
-
-      // Some input sources on Mac OS prevent
-      // the keypress event from being fired,
-      // so if we can't detect that the keypress
-      // event fired, we simulate the event
-      // here before the handler for the input
-      // event
-      if (!this.hasKeypressEvent) {
-        this.onKeypress(e as KeyboardEvent);
-      }
-
-      // Safari AutoFill fires CustomEvents
-      // LastPass sends an `isTrusted: false` property
-      // Since the input is changed all at once, set isFormatted
-      // to false so that reformatting actually occurs
-      if (event instanceof CustomEvent || !event.isTrusted) {
-        this.isFormatted = false;
-      }
-
-      this.reformatInput();
-    });
-
-    this.inputElement.addEventListener("paste", (event) => {
-      this.pasteEventHandler(event as ClipboardEvent);
-    });
+  private handleKeyPress(e: Event): void {
+	  this.hasKeypressEvent = true;
+	  this.onKeypress(e as KeyboardEvent);
+  }
+  
+  private handleKeyUp(): void {
+	  this.reformatInput();
+	  // if the user changes their keyboard and
+	  // the browser doesn't support the keypress event listener,
+	  // we need to reset the keypress flag to be able to enable the
+	  // fallback for the custom input event listener
+	  // to be able to format the field
+	  this.hasKeypressEvent = false;
+  }
+  
+  private handleInput(e: Event) {
+	  const event = e as KeyboardEvent;
+	
+	  // Some input sources on Mac OS prevent
+	  // the keypress event from being fired,
+	  // so if we can't detect that the keypress
+	  // event fired, we simulate the event
+	  // here before the handler for the input
+	  // event
+	  if (!this.hasKeypressEvent) {
+	    this.onKeypress(e as KeyboardEvent);
+	  }
+	
+	  // Safari AutoFill fires CustomEvents
+	  // LastPass sends an `isTrusted: false` property
+	  // Since the input is changed all at once, set isFormatted
+	  // to false so that reformatting actually occurs
+	  if (event instanceof CustomEvent || !event.isTrusted) {
+	    this.isFormatted = false;
+	  }
+	
+	  this.reformatInput();
+  }
+  
+  private handlePaste(event: Event): void {
+	  this.pasteEventHandler(event as ClipboardEvent);
   }
 
   protected isDeletion(event: KeyboardEvent): boolean {

--- a/src/lib/strategies/ie9.ts
+++ b/src/lib/strategies/ie9.ts
@@ -19,15 +19,27 @@ export class IE9Strategy extends BaseStrategy {
   }
 
   protected attachListeners(): void {
-    this.inputElement.addEventListener("keydown", (event) => {
-      this.keydownListener(event as KeyboardEvent);
-    });
-    this.inputElement.addEventListener("focus", () => {
-      this.format();
-    });
-    this.inputElement.addEventListener("paste", (event) => {
-      this.pasteEventHandler(event as ClipboardEvent);
-    });
+    this.inputElement.addEventListener("keydown", this.handleKeyDownIe9);
+    this.inputElement.addEventListener("focus", this.handleFocusIe9);
+    this.inputElement.addEventListener("paste", this.handlePasteIe9);
+  }
+  
+  destroy(): void {
+	  this.inputElement.removeEventListener("keydown", this.handleKeyDownIe9);
+	  this.inputElement.removeEventListener("focus", this.handleFocusIe9);
+	  this.inputElement.removeEventListener("paste", this.handlePasteIe9);
+  }
+  
+  private handleKeyDownIe9(event: Event): void {
+	  this.keydownListener(event as KeyboardEvent);
+  }
+  
+  private handleFocusIe9(): void {
+	  this.format();
+  }
+  
+  private handlePasteIe9(event: Event): void {
+	  this.pasteEventHandler(event as ClipboardEvent);
   }
 
   private format(): void {

--- a/src/lib/strategies/ios.ts
+++ b/src/lib/strategies/ios.ts
@@ -8,32 +8,44 @@ export class IosStrategy extends BaseStrategy {
   }
 
   protected attachListeners(): void {
-    this.inputElement.addEventListener("keydown", (event) => {
-      this.keydownListener(event as KeyboardEvent);
-    });
-    this.inputElement.addEventListener("input", (event) => {
-      const isCustomEvent = event instanceof CustomEvent;
-
-      // Safari AutoFill fires CustomEvents
-      // Set state to format before calling format listener
-      if (isCustomEvent) {
-        this.stateToFormat = {
-          selection: { start: 0, end: 0 },
-          value: this.inputElement.value,
-        };
-      }
-
-      this.formatListener();
-
-      if (!isCustomEvent) {
-        this.fixLeadingBlankSpaceOnIos();
-      }
-    });
-    this.inputElement.addEventListener("paste", (event) => {
-      this.pasteEventHandler(event as ClipboardEvent);
-    });
+    this.inputElement.addEventListener("keydown", this.handleKeyDownIos);
+    this.inputElement.addEventListener("input", this.handleInputIos);
+    this.inputElement.addEventListener("paste", this.handlePasteIos);
+  }
+  
+  destroy(): void {
+	  this.inputElement.removeEventListener("keydown", this.handleKeyDownIos);
+	  this.inputElement.removeEventListener("input", this.handleInputIos);
+	  this.inputElement.removeEventListener("paste", this.handlePasteIos);
+  }
+  
+  private handleKeyDownIos(event: Event): void {
+	  this.keydownListener(event as KeyboardEvent);
+  }
+  
+  private handleInputIos(event: Event): void {
+	  const isCustomEvent = event instanceof CustomEvent;
+	
+	  // Safari AutoFill fires CustomEvents
+	  // Set state to format before calling format listener
+	  if (isCustomEvent) {
+	    this.stateToFormat = {
+	      selection: { start: 0, end: 0 },
+	      value: this.inputElement.value,
+	    };
+	  }
+	
+	  this.formatListener();
+	
+	  if (!isCustomEvent) {
+	    this.fixLeadingBlankSpaceOnIos();
+	  }
   }
 
+  private handlePasteIos(event: Event): void {
+	  this.pasteEventHandler(event as ClipboardEvent);
+  }
+  
   // When deleting the last character on iOS, the cursor
   // is positioned as if there is a blank space when there
   // is not, setting it to '' in a setTimeout fixes it ¯\_(ツ)_/¯

--- a/src/lib/strategies/noop.ts
+++ b/src/lib/strategies/noop.ts
@@ -8,4 +8,8 @@ export class NoopKeyboardStrategy extends StrategyInterface {
   setPattern(): void {
     // noop
   }
+  
+  destroy(): void {
+    // noop
+  }
 }

--- a/src/lib/strategies/strategy-interface.ts
+++ b/src/lib/strategies/strategy-interface.ts
@@ -19,4 +19,5 @@ export abstract class StrategyInterface {
 
   abstract getUnformattedValue(): string;
   abstract setPattern(pattern: string): void;
+	abstract destroy(): void;
 }


### PR DESCRIPTION
### Summary

I was running into issues using this library within a single page app where I wasn't able to cleanup the event listeners and could end up with multiple instances of restricted-input trying to manage the same input element.

This adds a new method `destroy()` to each of the strategies that will remove all of the event listeners it creates.

### Checklist

- [ ] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @jamiebuilds-signal

### Reviewers

@braintree/team-sdk-js
