### PR TITLE
test: improve strategy coverage and fix weak assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 
 dist/
 dist-app/
+coverage/
 .env
 jsdoc/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Improve unit test coverage across strategy layer and fix weak assertions
+
 ## 4.2.0 (2026-03-04)
 
 - Move integration tests from wdio to playwright

--- a/package.json
+++ b/package.json
@@ -77,6 +77,18 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/dist"
-    ]
+    ],
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 80,
+        "statements": 80,
+        "branches": 80,
+        "functions": 80
+      }
+    }
   }
 }

--- a/src/lib/__mocks__/device.ts
+++ b/src/lib/__mocks__/device.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+/* global jest */
 export const isIE9 = jest.fn().mockReturnValue(false);
 export const isIos = jest.fn().mockReturnValue(false);
 export const isKitKatWebview = jest.fn().mockReturnValue(false);

--- a/src/lib/__mocks__/device.ts
+++ b/src/lib/__mocks__/device.ts
@@ -1,4 +1,3 @@
-/* global jest */
 export const isIE9 = jest.fn().mockReturnValue(false);
 export const isIos = jest.fn().mockReturnValue(false);
 export const isKitKatWebview = jest.fn().mockReturnValue(false);

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -3,7 +3,6 @@ const UA = (typeof window !== "undefined" &&
   window.navigator &&
   window.navigator.userAgent) as string;
 
-// TODO remove this when browser detection is converted to typescript
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import isAndroid from "@braintree/browser-detection/is-android";

--- a/test/unit/global.ts
+++ b/test/unit/global.ts
@@ -3,9 +3,7 @@ beforeEach(function () {
   // jsdom 26 adds ontouchend to document, causing Mac UAs to be falsely detected
   // as iPadOS in @braintree/browser-detection's isIos(). Remove it to simulate
   // a non-touch desktop browser environment.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (document as any).ontouchend;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (Document.prototype as any).ontouchend;
 });
 

--- a/test/unit/lib/input-selection.test.ts
+++ b/test/unit/lib/input-selection.test.ts
@@ -1,4 +1,7 @@
-import { get as getCurrentSelection } from "../../../src/lib/input-selection";
+import {
+  get as getCurrentSelection,
+  set as setSelection,
+} from "../../../src/lib/input-selection";
 
 describe("getCurrentSelection", function () {
   describe("element type", function () {
@@ -20,5 +23,31 @@ describe("getCurrentSelection", function () {
         });
       },
     );
+  });
+});
+
+describe("setSelection", function () {
+  it("calls setSelectionRange when element is the active element", function () {
+    const element = document.createElement("input");
+    element.value = "hello world";
+    document.body.appendChild(element);
+    element.focus();
+
+    jest.spyOn(element, "setSelectionRange");
+    setSelection(element, 2, 7);
+
+    expect(element.setSelectionRange).toHaveBeenCalledWith(2, 7);
+  });
+
+  it("does not call setSelectionRange when element is not active", function () {
+    const element = document.createElement("input");
+    element.value = "hello world";
+    document.body.appendChild(element);
+    // element is NOT focused — document.activeElement will be body
+
+    jest.spyOn(element, "setSelectionRange");
+    setSelection(element, 2, 7);
+
+    expect(element.setSelectionRange).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/lib/key-cannot-mutate-value.test.ts
+++ b/test/unit/lib/key-cannot-mutate-value.test.ts
@@ -1,0 +1,184 @@
+import { keyCannotMutateValue } from "../../../src/lib/key-cannot-mutate-value";
+
+function makeEvent(
+  overrides: Partial<KeyboardEvent> & { value?: string; start?: number },
+): KeyboardEvent {
+  const input = document.createElement("input");
+  input.value = overrides.value ?? "hello";
+  const start = overrides.start ?? 2;
+  input.setSelectionRange(start, start);
+  document.body.appendChild(input);
+  input.focus();
+
+  const event = new KeyboardEvent("keydown", {
+    key: overrides.key,
+    keyCode: overrides.keyCode,
+    shiftKey: overrides.shiftKey ?? false,
+    bubbles: true,
+  });
+
+  // currentTarget is normally set by the browser during dispatch; simulate it
+  Object.defineProperty(event, "currentTarget", { value: input });
+  Object.defineProperty(event, "srcElement", { value: input });
+
+  return event;
+}
+
+describe("keyCannotMutateValue", function () {
+  describe("event.key branch", function () {
+    it("falls through to keyCode when key is undefined", function () {
+      // undefined key, keyCode 65 ('a') → can mutate → false
+      const event = makeEvent({ key: undefined, keyCode: 65 });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+
+    it("falls through to keyCode when key is 'Unidentified'", function () {
+      const event = makeEvent({ key: "Unidentified", keyCode: 9 });
+      expect(keyCannotMutateValue(event)).toBe(true); // tab
+    });
+
+    it("falls through to keyCode when key is empty string", function () {
+      const event = makeEvent({ key: "", keyCode: 27 });
+      expect(keyCannotMutateValue(event)).toBe(true); // escape
+    });
+
+    it("returns false for Backspace when not at beginning", function () {
+      const event = makeEvent({ key: "Backspace", value: "hello", start: 2 });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+
+    it("returns true for Backspace when at beginning", function () {
+      const event = makeEvent({ key: "Backspace", value: "hello", start: 0 });
+      expect(keyCannotMutateValue(event)).toBe(true);
+    });
+
+    it("returns false for Delete when not at end", function () {
+      const event = makeEvent({ key: "Delete", value: "hello", start: 2 });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+
+    it("returns true for Delete when at end", function () {
+      const event = makeEvent({ key: "Delete", value: "hello", start: 5 });
+      expect(keyCannotMutateValue(event)).toBe(true);
+    });
+
+    it("returns false for Del when not at end", function () {
+      const event = makeEvent({ key: "Del", value: "hello", start: 2 });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+
+    it("returns true for Del when at end", function () {
+      const event = makeEvent({ key: "Del", value: "hello", start: 5 });
+      expect(keyCannotMutateValue(event)).toBe(true);
+    });
+
+    it("returns true for multi-char key (e.g. ArrowLeft)", function () {
+      const event = makeEvent({ key: "ArrowLeft" });
+      expect(keyCannotMutateValue(event)).toBe(true);
+    });
+
+    it("returns true for multi-char key (e.g. Enter)", function () {
+      const event = makeEvent({ key: "Enter" });
+      expect(keyCannotMutateValue(event)).toBe(true);
+    });
+
+    it("returns false for single printable char", function () {
+      const event = makeEvent({ key: "a" });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+
+    it("returns false for single digit char", function () {
+      const event = makeEvent({ key: "5" });
+      expect(keyCannotMutateValue(event)).toBe(false);
+    });
+  });
+
+  describe("event.keyCode branch (key is undefined/unidentified/empty)", function () {
+    function makeKeyCodeEvent(
+      keyCode: number,
+      opts: { shiftKey?: boolean; value?: string; start?: number } = {},
+    ): KeyboardEvent {
+      return makeEvent({
+        key: undefined,
+        keyCode,
+        shiftKey: opts.shiftKey ?? false,
+        value: opts.value,
+        start: opts.start,
+      });
+    }
+
+    it("returns true for Tab (9)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(9))).toBe(true);
+    });
+
+    it("returns true for Pause/Break (19)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(19))).toBe(true);
+    });
+
+    it("returns true for Caps Lock (20)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(20))).toBe(true);
+    });
+
+    it("returns true for Escape (27)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(27))).toBe(true);
+    });
+
+    it("returns true for right arrow (39)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(39))).toBe(true);
+    });
+
+    it("returns true for Insert (45)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(45))).toBe(true);
+    });
+
+    describe("shift-sensitive keys (33-38, 40)", function () {
+      [33, 34, 35, 36, 37, 38, 40].forEach((code) => {
+        it(`returns true for keyCode ${code} without shift`, function () {
+          expect(keyCannotMutateValue(makeKeyCodeEvent(code))).toBe(true);
+        });
+
+        it(`returns false for keyCode ${code} with shift`, function () {
+          expect(
+            keyCannotMutateValue(makeKeyCodeEvent(code, { shiftKey: true })),
+          ).toBe(false);
+        });
+      });
+    });
+
+    it("returns true for Backspace (8) at beginning", function () {
+      expect(
+        keyCannotMutateValue(makeKeyCodeEvent(8, { value: "hello", start: 0 })),
+      ).toBe(true);
+    });
+
+    it("returns false for Backspace (8) not at beginning", function () {
+      expect(
+        keyCannotMutateValue(makeKeyCodeEvent(8, { value: "hello", start: 2 })),
+      ).toBe(false);
+    });
+
+    it("returns true for Delete (46) at end", function () {
+      expect(
+        keyCannotMutateValue(
+          makeKeyCodeEvent(46, { value: "hello", start: 5 }),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false for Delete (46) not at end", function () {
+      expect(
+        keyCannotMutateValue(
+          makeKeyCodeEvent(46, { value: "hello", start: 2 }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for unknown keyCode (default)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(65))).toBe(false);
+    });
+
+    it("returns false for keyCode 0 (default)", function () {
+      expect(keyCannotMutateValue(makeKeyCodeEvent(0))).toBe(false);
+    });
+  });
+});

--- a/test/unit/lib/strategies/android-chrome.test.ts
+++ b/test/unit/lib/strategies/android-chrome.test.ts
@@ -1,5 +1,11 @@
 import { AndroidChromeStrategy } from "../../../../src/lib/strategies/android-chrome";
 import { BaseStrategy } from "../../../../src/lib/strategies/base";
+import * as keyCannotMutateValueModule from "../../../../src/lib/key-cannot-mutate-value";
+import { makeInput as makeInputBase } from "./helpers";
+
+function makeInput(value = ""): HTMLInputElement {
+  return makeInputBase(value, true);
+}
 
 describe("Android Chrome Strategy", function () {
   describe("constructor()", function () {
@@ -11,6 +17,166 @@ describe("Android Chrome Strategy", function () {
       const strategy = new AndroidChromeStrategy(options);
 
       expect(strategy).toBeInstanceOf(BaseStrategy);
+    });
+
+    it("adds android-chrome specific listeners", function () {
+      const input = document.createElement("input");
+      jest.spyOn(input, "addEventListener");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9}}",
+      });
+
+      ["keydown", "keyup", "input", "paste"].forEach((event) => {
+        expect(strategy.inputElement.addEventListener).toHaveBeenCalledWith(
+          event,
+          expect.any(Function),
+        );
+      });
+    });
+  });
+
+  describe("keydown handler", function () {
+    it("unformats input when key can mutate value", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeInput("4111");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+      strategy.isFormatted = true;
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "1" }),
+      );
+
+      expect(strategy.isFormatted).toBe(false);
+    });
+
+    it("does not unformat when keyCannotMutateValue is true", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(true);
+
+      const input = makeInput("4111");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+      strategy.isFormatted = true;
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" }),
+      );
+
+      expect(strategy.isFormatted).toBe(true);
+    });
+  });
+
+  describe("keyup handler", function () {
+    it("calls reformatInput", function () {
+      const input = makeInput("4111");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+      strategy.isFormatted = false;
+
+      input.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+
+      expect(strategy.isFormatted).toBe(true);
+    });
+  });
+
+  describe("input handler", function () {
+    it("calls reformatInput", function () {
+      const input = makeInput("4111");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+      strategy.isFormatted = false;
+
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(strategy.isFormatted).toBe(true);
+    });
+  });
+
+  describe("prePasteEventHandler()", function () {
+    it("is a noop and does not call event.preventDefault", function () {
+      const input = makeInput("12");
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+
+      // Call prePasteEventHandler directly with a fake event
+      const fakeEvent = {
+        preventDefault: jest.fn(),
+      } as unknown as ClipboardEvent;
+      (strategy as any).prePasteEventHandler(fakeEvent);
+
+      expect(fakeEvent.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("postPasteEventHandler()", function () {
+    it("calls reformatAfterPaste inside a setTimeout", function () {
+      jest.useFakeTimers();
+
+      const input = makeInput("12");
+      input.setSelectionRange(2, 2);
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+
+      const reformatSpy = jest.spyOn(strategy as any, "reformatAfterPaste");
+
+      // Trigger postPasteEventHandler directly
+      (strategy as any).postPasteEventHandler();
+
+      expect(reformatSpy).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+
+      expect(reformatSpy).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe("afterReformatInput()", function () {
+    it("resets selection to formatted end position inside a setTimeout", function () {
+      jest.useFakeTimers();
+
+      const input = makeInput("4111");
+      input.setSelectionRange(0, 0);
+      const strategy = new AndroidChromeStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+
+      jest.spyOn(input, "setSelectionRange");
+
+      const formattedState = {
+        value: "4111",
+        selection: { start: 4, end: 4 },
+      };
+
+      (strategy as any).afterReformatInput(formattedState);
+
+      expect(input.setSelectionRange).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+
+      expect(input.setSelectionRange).toHaveBeenCalledWith(4, 4);
+
+      jest.useRealTimers();
     });
   });
 });

--- a/test/unit/lib/strategies/base.test.ts
+++ b/test/unit/lib/strategies/base.test.ts
@@ -1,5 +1,7 @@
 import { BaseStrategy } from "../../../../src/lib/strategies/base";
 import { StrategyOptions } from "../../../../src/lib/strategies/strategy-interface";
+import * as keyCannotMutateValueModule from "../../../../src/lib/key-cannot-mutate-value";
+import { makeInput, fireEvent } from "./helpers";
 
 describe("Base Strategy", function () {
   let options: StrategyOptions;
@@ -60,6 +62,241 @@ describe("Base Strategy", function () {
       });
 
       expect(strategy.getUnformattedValue(true)).toBe("unformatted value");
+    });
+  });
+
+  describe("event handlers", function () {
+    describe("keydown handler", function () {
+      it("returns early without reformatting when keyCannotMutateValue is true", function () {
+        jest
+          .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+          .mockReturnValue(true);
+        const input = makeInput("4111");
+        // eslint-disable-next-line no-new
+        new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        const originalValue = input.value;
+
+        fireEvent(input, "keydown", { key: "ArrowLeft" });
+
+        expect(input.value).toBe(originalValue);
+      });
+
+      it("unformats input on deletion key", function () {
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = true;
+
+        jest
+          .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+          .mockReturnValue(false);
+
+        fireEvent(input, "keydown", { key: "Backspace" });
+
+        expect(strategy.isFormatted).toBe(false);
+      });
+
+      it("marks isFormatted false when simulated event fires (no key or keyCode)", function () {
+        // keyCannotMutateValue returns false for key="" / keyCode=0 (hits default branch),
+        // so execution continues past the early-return. Mock it explicitly so this test
+        // is not sensitive to changes in that utility.
+        jest
+          .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+          .mockReturnValue(false);
+
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = true;
+
+        // Simulated event: key='' and keyCode=0 — both falsy, so isSimulatedEvent() is true
+        const event = new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "",
+          keyCode: 0,
+        });
+        input.dispatchEvent(event);
+
+        expect(strategy.isFormatted).toBe(false);
+      });
+    });
+
+    describe("keypress handler", function () {
+      it("calls unformatInput via onKeypress", function () {
+        jest
+          .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+          .mockReturnValue(false);
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = true;
+
+        fireEvent(input, "keypress", { key: "a" });
+
+        expect(strategy.isFormatted).toBe(false);
+      });
+    });
+
+    describe("keyup handler", function () {
+      it("reformats input", function () {
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = false;
+
+        fireEvent(input, "keyup");
+
+        expect(strategy.isFormatted).toBe(true);
+      });
+    });
+
+    describe("input handler", function () {
+      it("calls reformatInput when hasKeypressEvent is false (autofill path)", function () {
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = false;
+
+        // Fire input without a preceding keypress so hasKeypressEvent stays false
+        fireEvent(input, "input");
+
+        expect(strategy.isFormatted).toBe(true);
+      });
+
+      it("resets isFormatted to false for CustomEvent before reformatting", function () {
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = true;
+
+        // Intercept reformatInput to capture isFormatted at the moment it is called.
+        // This is the only observable point where the reset-to-false is visible,
+        // since reformatInput immediately sets it back to true.
+        let isFormattedWhenReformatCalled: boolean | undefined;
+        jest
+          .spyOn(strategy as any, "reformatInput")
+          .mockImplementation(function () {
+            isFormattedWhenReformatCalled = strategy.isFormatted;
+          });
+
+        input.dispatchEvent(new CustomEvent("input", { bubbles: true }));
+
+        expect(isFormattedWhenReformatCalled).toBe(false);
+      });
+
+      it("resets isFormatted to false for untrusted non-CustomEvent (e.g. LastPass) before reformatting", function () {
+        const input = makeInput("4111");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+        strategy.isFormatted = true;
+
+        // jsdom always sets isTrusted=false on synthetic events (non-configurable),
+        // so a plain Event exercises the !event.isTrusted branch in the handler.
+        // Intercept reformatInput to observe isFormatted before it is reset to true.
+        let isFormattedWhenReformatCalled: boolean | undefined;
+        jest
+          .spyOn(strategy as any, "reformatInput")
+          .mockImplementation(function () {
+            isFormattedWhenReformatCalled = strategy.isFormatted;
+          });
+
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+
+        expect(isFormattedWhenReformatCalled).toBe(false);
+      });
+    });
+
+    describe("paste handler (pasteEventHandler)", function () {
+      it("reads clipboard data and splices into current value", function () {
+        const input = makeInput("12");
+        input.setSelectionRange(2, 2);
+
+        const onPasteEvent = jest.fn();
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+          onPasteEvent,
+        });
+
+        // Call pasteEventHandler directly with a fake ClipboardEvent-like object
+        const fakeEvent = {
+          preventDefault: jest.fn(),
+          clipboardData: { getData: jest.fn().mockReturnValue("34") },
+        } as unknown as ClipboardEvent;
+
+        (strategy as any).pasteEventHandler(fakeEvent);
+
+        expect(onPasteEvent).toHaveBeenCalledWith({
+          unformattedInputValue: expect.stringContaining("34"),
+        });
+        expect(input.value).toContain("34");
+      });
+
+      it("falls back to window.clipboardData when event.clipboardData is absent", function () {
+        const input = makeInput("12");
+        input.setSelectionRange(2, 2);
+
+        const onPasteEvent = jest.fn();
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+          onPasteEvent,
+        });
+
+        // Simulate IE: no event.clipboardData, but window.clipboardData exists
+        (window as any).clipboardData = {
+          getData: jest.fn().mockReturnValue("56"),
+        };
+
+        const fakeEvent = {
+          preventDefault: jest.fn(),
+          clipboardData: null,
+        } as unknown as ClipboardEvent;
+
+        (strategy as any).pasteEventHandler(fakeEvent);
+
+        expect(onPasteEvent).toHaveBeenCalledWith({
+          unformattedInputValue: expect.stringContaining("56"),
+        });
+
+        // Cleanup
+        (window as any).clipboardData = undefined;
+      });
+
+      it("dispatches paste event listener through the input element", function () {
+        const input = makeInput("12");
+        const strategy = new BaseStrategy({
+          element: input,
+          pattern: "{{9999}}",
+        });
+
+        const pasteHandlerSpy = jest.spyOn(
+          strategy as any,
+          "pasteEventHandler",
+        );
+        // Use a plain Event dispatched as "paste" — the listener will call pasteEventHandler
+        const event = new Event("paste", { bubbles: true });
+        input.dispatchEvent(event);
+
+        expect(pasteHandlerSpy).toHaveBeenCalled();
+      });
     });
   });
 

--- a/test/unit/lib/strategies/helpers.ts
+++ b/test/unit/lib/strategies/helpers.ts
@@ -1,0 +1,26 @@
+export function makeInput(value = "", focused = false): HTMLInputElement {
+  const input = document.createElement("input");
+  input.value = value;
+  document.body.appendChild(input);
+  if (focused) {
+    input.focus();
+  }
+  return input;
+}
+
+export function fireEvent(
+  element: HTMLInputElement,
+  type: string,
+  init: Record<string, unknown> = {},
+): Event {
+  let event: Event;
+  if (type === "keydown" || type === "keypress" || type === "keyup") {
+    event = new KeyboardEvent(type, { bubbles: true, ...init });
+  } else if (type === "paste") {
+    event = new ClipboardEvent(type, { bubbles: true, ...init });
+  } else {
+    event = new Event(type, { bubbles: true, ...init });
+  }
+  element.dispatchEvent(event);
+  return event;
+}

--- a/test/unit/lib/strategies/ie9.test.ts
+++ b/test/unit/lib/strategies/ie9.test.ts
@@ -1,6 +1,14 @@
 import { IE9Strategy } from "../../../../src/lib/strategies/ie9";
 import { BaseStrategy } from "../../../../src/lib/strategies/base";
 import { StrategyOptions } from "../../../../src/lib/strategies/strategy-interface";
+import * as keyCannotMutateValueModule from "../../../../src/lib/key-cannot-mutate-value";
+import { makeInput } from "./helpers";
+
+// IE9Strategy tests use a focused input because setSelectionRange requires
+// the element to be the active element.
+function makeFocusedInput(value = ""): HTMLInputElement {
+  return makeInput(value, true);
+}
 
 describe("IE9 Strategy", function () {
   let options: StrategyOptions;
@@ -43,6 +51,133 @@ describe("IE9 Strategy", function () {
       });
 
       expect(strategy.getUnformattedValue()).toBe("unformatted value");
+    });
+  });
+
+  describe("keydown listener", function () {
+    it("returns early when keyCannotMutateValue is true", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(true);
+
+      const input = makeFocusedInput("4");
+      const strategy = new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      const formatSpy = jest.spyOn(strategy as any, "format");
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" }),
+      );
+
+      expect(formatSpy).not.toHaveBeenCalled();
+    });
+
+    it("calls simulateDeletion and formats on deletion key", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeFocusedInput("4");
+      input.setSelectionRange(1, 1);
+      const strategy = new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      const simulateDeletionSpy = jest
+        .spyOn(strategy.formatter, "simulateDeletion")
+        .mockReturnValue({ value: "", selection: { start: 0, end: 0 } });
+      const formatSpy = jest.spyOn(strategy as any, "format");
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "Backspace",
+          keyCode: 8,
+        }),
+      );
+
+      expect(simulateDeletionSpy).toHaveBeenCalled();
+      expect(formatSpy).toHaveBeenCalled();
+    });
+
+    it("constructs new value from inserted key and formats on normal key", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeFocusedInput("1");
+      input.setSelectionRange(1, 1);
+      // eslint-disable-next-line no-new
+      new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "2" }),
+      );
+
+      // IE9Strategy manually builds the new value from the pressed key and formats it
+      expect(input.value).toBe("12");
+    });
+
+    it("unformats stateToFormat when cursor is at end of new value", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeFocusedInput("1");
+      // Cursor at end so insertion at end triggers unformat branch
+      input.setSelectionRange(1, 1);
+      const strategy = new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      const unformatSpy = jest
+        .spyOn(strategy.formatter, "unformat")
+        .mockReturnValue({
+          value: "12",
+          selection: { start: 2, end: 2 },
+        });
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "2" }),
+      );
+
+      // new value = "1" + "2" = "12", padded selection = {start:2, end:2},
+      // selection.start (2) === newValue.length (2), so unformat is called with that state.
+      expect(unformatSpy).toHaveBeenCalledWith({
+        value: "12",
+        selection: { start: 2, end: 2 },
+      });
+    });
+  });
+
+  describe("focus listener", function () {
+    it("formats the input on focus", function () {
+      const input = makeFocusedInput("4111");
+      const strategy = new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      strategy.isFormatted = false;
+      const formatSpy = jest.spyOn(strategy as any, "format");
+
+      input.dispatchEvent(new Event("focus", { bubbles: true }));
+
+      expect(formatSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("reformatAfterPaste()", function () {
+    it("formats value and defers selection via setTimeout", function () {
+      jest.useFakeTimers();
+
+      const input = makeFocusedInput("4111");
+      input.setSelectionRange(2, 2);
+      const strategy = new IE9Strategy({ element: input, pattern: "{{9999}}" });
+
+      jest.spyOn(input, "setSelectionRange");
+
+      (strategy as any).reformatAfterPaste();
+
+      jest.runAllTimers();
+
+      // reformatAfterPaste pads the original selection by 1 before deferring it,
+      // so selection {start:2, end:2} becomes {start:3, end:3}.
+      expect(input.setSelectionRange).toHaveBeenLastCalledWith(3, 3);
+
+      jest.useRealTimers();
     });
   });
 });

--- a/test/unit/lib/strategies/ios.test.ts
+++ b/test/unit/lib/strategies/ios.test.ts
@@ -1,6 +1,12 @@
 import { IosStrategy } from "../../../../src/lib/strategies/ios";
 import { BaseStrategy } from "../../../../src/lib/strategies/base";
 import { StrategyOptions } from "../../../../src/lib/strategies/strategy-interface";
+import * as keyCannotMutateValueModule from "../../../../src/lib/key-cannot-mutate-value";
+import { makeInput as makeInputBase } from "./helpers";
+
+function makeInput(value = ""): HTMLInputElement {
+  return makeInputBase(value, true);
+}
 
 describe("iOS Strategy", function () {
   let options: StrategyOptions;
@@ -43,6 +49,153 @@ describe("iOS Strategy", function () {
       });
 
       expect(strategy.getUnformattedValue()).toBe("unformatted value");
+    });
+  });
+
+  describe("keydown listener", function () {
+    it("returns early when keyCannotMutateValue is true", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(true);
+
+      const input = makeInput("4");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" }),
+      );
+
+      // stateToFormat should not be set when returning early
+      expect((strategy as any).stateToFormat).toBeUndefined();
+    });
+
+    it("calls simulateDeletion and sets stateToFormat on deletion key", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeInput("4");
+      input.setSelectionRange(1, 1);
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      const mockState = { value: "", selection: { start: 0, end: 0 } };
+      const simulateSpy = jest
+        .spyOn(strategy.formatter, "simulateDeletion")
+        .mockReturnValue(mockState);
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "Backspace",
+          keyCode: 8,
+        }),
+      );
+
+      expect(simulateSpy).toHaveBeenCalled();
+      expect((strategy as any).stateToFormat).toBe(mockState);
+    });
+
+    it("does not set stateToFormat for non-deletion key", function () {
+      jest
+        .spyOn(keyCannotMutateValueModule, "keyCannotMutateValue")
+        .mockReturnValue(false);
+
+      const input = makeInput("4");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "5" }),
+      );
+
+      expect((strategy as any).stateToFormat).toBeUndefined();
+    });
+  });
+
+  describe("input listener", function () {
+    it("formats input on normal input event", function () {
+      const input = makeInput("4");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      strategy.isFormatted = false;
+      const formatListenerSpy = jest.spyOn(strategy as any, "formatListener");
+
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(formatListenerSpy).toHaveBeenCalled();
+    });
+
+    it("sets stateToFormat from current value on CustomEvent (Safari AutoFill)", function () {
+      const input = makeInput("4111111111111111");
+      // eslint-disable-next-line no-new
+      new IosStrategy({
+        element: input,
+        pattern: "{{9999}} {{9999}} {{9999}} {{9999}}",
+      });
+
+      const customEvent = new CustomEvent("input", { bubbles: true });
+      input.dispatchEvent(customEvent);
+
+      // stateToFormat is set then consumed by formatListener, so value should be formatted
+      expect(input.value).toBe("4111 1111 1111 1111");
+    });
+
+    it("calls fixLeadingBlankSpaceOnIos for non-CustomEvent", function () {
+      const input = makeInput("");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      const fixSpy = jest.spyOn(strategy as any, "fixLeadingBlankSpaceOnIos");
+
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(fixSpy).toHaveBeenCalled();
+    });
+
+    it("does NOT call fixLeadingBlankSpaceOnIos for CustomEvent", function () {
+      const input = makeInput("4");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      const fixSpy = jest.spyOn(strategy as any, "fixLeadingBlankSpaceOnIos");
+
+      input.dispatchEvent(new CustomEvent("input", { bubbles: true }));
+
+      expect(fixSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fixLeadingBlankSpaceOnIos()", function () {
+    it("sets value to empty string in a setTimeout when value is empty", function () {
+      jest.useFakeTimers();
+
+      const input = makeInput("");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      (strategy as any).fixLeadingBlankSpaceOnIos();
+
+      // Before timer runs, value is still ""
+      input.value = "  "; // simulate blank space iOS cursor issue
+
+      jest.runAllTimers();
+
+      expect(input.value).toBe("");
+
+      jest.useRealTimers();
+    });
+
+    it("does not run the setTimeout when value is not empty", function () {
+      jest.useFakeTimers();
+
+      const input = makeInput("4");
+      const strategy = new IosStrategy({ element: input, pattern: "{{9999}}" });
+
+      // Manually invoke with non-empty value
+      input.value = "4";
+      (strategy as any).fixLeadingBlankSpaceOnIos();
+
+      // No timer should have been scheduled — check before running timers so
+      // we assert on the scheduling decision, not just side-effects.
+      expect(jest.getTimerCount()).toBe(0);
+
+      jest.useRealTimers();
     });
   });
 });

--- a/test/unit/lib/strategies/old-android-chrome-based-webview.test.ts
+++ b/test/unit/lib/strategies/old-android-chrome-based-webview.test.ts
@@ -1,5 +1,10 @@
 import { AndroidChromeStrategy } from "../../../../src/lib/strategies/android-chrome";
 import { KitKatChromiumBasedWebViewStrategy } from "../../../../src/lib/strategies/kitkat-chromium-based-webview";
+import { makeInput as makeInputBase } from "./helpers";
+
+function makeInput(value = ""): HTMLInputElement {
+  return makeInputBase(value, true);
+}
 
 describe("Old Android Chrome Based Webview Strategy", function () {
   describe("constructor()", function () {
@@ -11,6 +16,61 @@ describe("Old Android Chrome Based Webview Strategy", function () {
       const strategy = new KitKatChromiumBasedWebViewStrategy(options);
 
       expect(strategy).toBeInstanceOf(AndroidChromeStrategy);
+    });
+  });
+
+  describe("reformatInput()", function () {
+    it("wraps super.reformatInput() in a setTimeout", function () {
+      jest.useFakeTimers();
+
+      const input = makeInput("4111");
+      const strategy = new KitKatChromiumBasedWebViewStrategy({
+        element: input,
+        pattern: "{{9999}}",
+      });
+
+      // Reset so we can detect the reformat
+      strategy.isFormatted = false;
+
+      // Call reformatInput — it should NOT reformat immediately
+      (strategy as any).reformatInput();
+
+      expect(strategy.isFormatted).toBe(false);
+
+      jest.runAllTimers();
+
+      expect(strategy.isFormatted).toBe(true);
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe("unformatInput()", function () {
+    it("wraps super.unformatInput() in a setTimeout", function () {
+      jest.useFakeTimers();
+
+      // Use a value with a format character so input.value is a concrete
+      // observable: "4111 1111" (formatted) → "41111111" (unformatted).
+      const input = makeInput("4111 1111");
+      const strategy = new KitKatChromiumBasedWebViewStrategy({
+        element: input,
+        pattern: "{{9999}} {{9999}}",
+      });
+
+      strategy.isFormatted = true;
+
+      // Call unformatInput — it should NOT unformat immediately
+      (strategy as any).unformatInput();
+
+      expect(strategy.isFormatted).toBe(true);
+      expect(input.value).toBe("4111 1111"); // value unchanged synchronously
+
+      jest.runAllTimers();
+
+      expect(strategy.isFormatted).toBe(false);
+      expect(input.value).toBe("41111111"); // format character removed asynchronously
+
+      jest.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
# Summary of changes

- Extract shared `makeInput`/`fireEvent` helpers to eliminate duplication across strategy test files
- Add full coverage for `keyCannotMutateValue` and `input-selection` utilities
- Add event handler tests for all strategies (`Base`, `IE9`, `iOS`, `AndroidChrome`, `KitKatChromiumBasedWebView`)
- Fix `CustomEvent`/`isTrusted` input handler tests to spy on `reformatInput` and assert `isFormatted` at reset time, rather than testing final state that is always `true`
- Enable Jest coverage collection with an 80% threshold

## Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

### Reviewers

@braintree/team-sdk-js