### PR TITLE
Update versions for actions to v6

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,4 +40,4 @@ jobs:
     env:
       CI: true
       HOST: "localhost"
-      DISABLE_RETRIES: true
+      DISABLE_RETRIES: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,4 +40,3 @@ jobs:
     env:
       CI: true
       HOST: "localhost"
-      DISABLE_RETRIES: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: "BrowserStack Test on Ubuntu"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: "BrowserStack Env Setup"
         uses: "browserstack/github-actions/setup-env@master"
         with:
@@ -28,7 +28,7 @@ jobs:
           local-testing: start
           local-identifier: random
       - name: "Node Setup"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
       - run: npm install

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -10,8 +10,8 @@ jobs:
   publish-gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: ${{ env.NPM_REGISTRY }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,8 +10,8 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Github Credentials
         run: |
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 

--- a/test/integration/playwright.config.ts
+++ b/test/integration/playwright.config.ts
@@ -66,7 +66,7 @@ module.exports = defineConfig({
   testMatch: "**/restricted-input.spec.ts",
   fullyParallel: true,
   retries: 2,
-  workers: 1,
+  workers: 3,
   reporter: [["list"], ["html"]],
   timeout: 90000,
   globalSetup: require.resolve("./global-setup"),

--- a/test/integration/playwright.config.ts
+++ b/test/integration/playwright.config.ts
@@ -65,8 +65,8 @@ module.exports = defineConfig({
   testDir: "./",
   testMatch: "**/restricted-input.spec.ts",
   fullyParallel: true,
-  retries: process.env.DISABLE_RETRIES ? 0 : 2,
-  workers: 4,
+  retries: 2,
+  workers: 1,
   reporter: [["list"], ["html"]],
   timeout: 90000,
   globalSetup: require.resolve("./global-setup"),
@@ -87,6 +87,7 @@ module.exports = defineConfig({
           wsEndpoint: `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(
             JSON.stringify(getCaps(browser)),
           )}`,
+          timeout: 60000,
         },
       },
     }),


### PR DESCRIPTION
# Summary of changes

- Updating actions in Github Actions to use latest versions.
- This warning will still be present because of the Browserstack actions we are using. Those actions use older node versions under the hood and we do not have the ability to change that, it will fall on Browserstack to release an update to their actions using more recent versions of node.
<img width="1333" height="305" alt="Screenshot 2026-04-15 at 11 26 19 AM" src="https://github.com/user-attachments/assets/d61f9e66-1927-4c68-9a59-042f90414b79" />


## Checklist

- [ ] ~~Added a changelog entry~~(Not needed for this change)
- [X] Relevant test coverage
- [X] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@codentacos 

### Reviewers

@braintree/team-sdk-js
