### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed # main
     with:
       lint-command: "npx prettier --check ."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@17a3922575160e8e3ffdb7ecc76c6a3dbfd6a50a
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main
     with:
       lint-command: "npx prettier --check ."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,27 +14,27 @@ jobs:
     name: "BrowserStack Test on Ubuntu"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: "BrowserStack Env Setup"
-        uses: "browserstack/github-actions/setup-env@master"
+        uses: browserstack/github-actions/setup-env@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
         with:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           build-name: BUILD_INFO
           project-name: REPO_NAME
       - name: "BrowserStackLocal Setup"
-        uses: "browserstack/github-actions/setup-local@master"
+        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
         with:
           local-testing: start
           local-identifier: random
       - name: "Node Setup"
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
       - run: npm install
       - run: npm run test:integration
       - name: "BrowserStackLocal Stop"
-        uses: "browserstack/github-actions/setup-local@master"
+        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
         with:
           local-testing: stop
     env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,27 +14,27 @@ jobs:
     name: "BrowserStack Test on Ubuntu"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: "BrowserStack Env Setup"
-        uses: browserstack/github-actions/setup-env@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
+        uses: browserstack/github-actions/setup-env@110c0a843fea32c53638e18e7fd54e52200bfc2d # master
         with:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           build-name: BUILD_INFO
           project-name: REPO_NAME
       - name: "BrowserStackLocal Setup"
-        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
+        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d # master
         with:
           local-testing: start
           local-identifier: random
       - name: "Node Setup"
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
       - run: npm install
       - run: npm run test:integration
       - name: "BrowserStackLocal Stop"
-        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d  # master
+        uses: browserstack/github-actions/setup-local@110c0a843fea32c53638e18e7fd54e52200bfc2d # master
         with:
           local-testing: stop
     env:

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -10,8 +10,8 @@ jobs:
   publish-gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -10,8 +10,8 @@ jobs:
   publish-gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           registry-url: ${{ env.NPM_REGISTRY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
           registry-url: ${{ env.NPM_REGISTRY }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,8 +10,8 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1 (deprecated; migrate off)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,8 +10,8 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1 (deprecated; migrate off)
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1 (deprecated; migrate off)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   codeql-javascript:
-    uses: braintree/security-workflows/.github/workflows/codeql.yml@main
+    uses: braintree/security-workflows/.github/workflows/codeql.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main
     with:
       language: javascript-typescript
   dependency-review:
-    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@main
+    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   codeql-javascript:
-    uses: braintree/security-workflows/.github/workflows/codeql.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main
+    uses: braintree/security-workflows/.github/workflows/codeql.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214 # main
     with:
       language: javascript-typescript
   dependency-review:
-    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main
+    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214 # main

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Configure Github Credentials
         run: |
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Configure Github Credentials
         run: |
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.59.1",
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "browserify": "^17.0.1",
@@ -32,7 +32,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "jest-util": "^30.2.0",
         "jsdoc": "^4.0.5",
-        "playwright": "1.58.2",
+        "playwright": "1.59.1",
         "prettier": "^3.8.1",
         "ts-jest": "^29.4.6",
         "tsify": "^5.0.4",
@@ -2521,13 +2521,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11379,13 +11379,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11398,9 +11398,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.59.1",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "browserify": "^17.0.1",
@@ -70,7 +70,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-util": "^30.2.0",
     "jsdoc": "^4.0.5",
-    "playwright": "1.58.2",
+    "playwright": "1.59.1",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
     "tsify": "^5.0.4",


### PR DESCRIPTION
## Summary

- Pins GitHub Actions and reusable workflow references to full-length commit SHAs, per GitHub's secure-use guidance for third-party actions. SHA-pinned refs carry a trailing comment with the original tag/branch for readability.
- Upgrades playwright to `1.59.1` to resolve an issue with Firefox tests timing out

## Checklist

- [ ] ~Added a changelog entry:~ N/A
- [ ] ~Relevant test coverage:~ N/A
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@lvandenboom 

### Reviewers

@braintree/team-sdk-js